### PR TITLE
[Template Sync] Update legal copyright information

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,4 +126,4 @@ extra_css:
 
 # Copyright
 copyright: |
-  &copy; 2026 <a href="https://github.com/thd-spatial"  target="_blank" rel="noopener">THD-Spatial</a>
+  &copy; 2026 <a href="https://github.com/thd-spatial"  target="_blank" rel="noopener">BigGeoData & Spatial AI, Technische Hochschule Deggendorf</a>


### PR DESCRIPTION
## Template Sync: Legal Copyright Update

This PR updates the copyright holder to match the central template.

**New copyright holder:** `BigGeoData & Spatial AI, Technische Hochschule Deggendorf`

**Files updated (where present and changed):**
- `LICENSE` — copyright holder line (license type and year preserved)
- `mkdocs.yml` — `copyright:` field
- `CITATION.cff` — `affiliation:` field(s)
- `README.md` — any copyright lines

---
To opt out of future syncs for specific files, create `.github/.templatesync-ignore` with one filename per line. Use `*` to skip this repo entirely.

*Auto-generated by [GitHub Template Sync](https://github.com/THD-Spatial-AI/github-template)*
