### PR TITLE
ci: fetch LFS objects during integration test checkout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Set up Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
Without lfs: true, actions/checkout leaves seed SQL files as LFS pointer files, causing psql to fail with syntax errors.