### PR TITLE
fix: docker env setup (citydb-tool bump, TABULA reload on reset, ROOM_HEIGHT)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,7 +114,7 @@ LOG_LEVEL=INFO
 # Import limit caps features pulled from GML files by the citydb-tool in citydb Useful for creating a small test DB without importing the full dataset. Does not affect subsequent feature extraction runs on an already-imported DB.
 #
 # e.g. 1000  (0 or empty = import everything)
-IMPORT_LIMIT=0         
+IMPORT_LIMIT=0
 
 # Building limit caps how many buildings the City2TABULA extraction pipeline processes. Set this to debug or benchmark against a subset of an already-imported DB. Independent of IMPORT_LIMIT, the DB can hold 50k buildings while you only process 100 of them.
 #
@@ -124,7 +124,10 @@ BUILDING_LIMIT=0
 # Validation limit caps matched validation pairs per category (buildings, roof surfaces, wall surfaces, floor surfaces). The load functions JOIN directly with City2TABULA tables and apply LIMIT at the DB level, so validation continues until N matches are found or the full dataset is exhausted. Sampling is random (ORDER BY RANDOM() in SQL).
 #
 # e.g. 10000  (0 or empty = validate all available matches)
-VALIDATION_LIMIT=0    
+VALIDATION_LIMIT=0
 
 # Define maximum 2D distance in metres between building footprints for two buildings to be considered neighbours. Accounts for small gaps in CityGML data between adjacent buildings.
 NEIGHBOUR_TOLERANCE=0.5
+
+# Define the default room height in metres for buildings without a defined height in the CityGML data. This is used to generate 3D building models for buildings with missing height information.
+ROOM_HEIGHT=3

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -37,7 +37,7 @@ ENV PATH="${JAVA_HOME}/bin:${PATH}"
 # -----------------------------
 # Install citydb-tool
 # -----------------------------
-RUN wget -q https://github.com/3dcitydb/citydb-tool/releases/download/v1.1.0/citydb-tool-1.1.0.zip -O /tmp/citydb-tool.zip \
+RUN wget -q https://github.com/3dcitydb/citydb-tool/releases/download/v1.3.2/citydb-tool-1.3.2.zip -O /tmp/citydb-tool.zip \
     && unzip /tmp/citydb-tool.zip -d /usr/local/citydb-tool \
     && rm /tmp/citydb-tool.zip
 
@@ -70,4 +70,4 @@ RUN echo 'export GOROOT=/usr/local/go' >> /home/appuser/.bashrc \
 # -----------------------------
 # Default command
 # -----------------------------
-CMD ["bash", "-lc", "echo 'Go:' $(go version); echo 'Java:' $(java -version 2>&1 | head -n 1); echo 'citydb-tool:' $(/usr/local/citydb-tool/citydb --version); exec bash"]
+CMD ["bash", "-lc", "echo 'Go:' $(go version); echo 'Java:' $(java -version 2>&1 | head -n 1); echo 'citydb-tool:' $(/usr/local/citydb-tool/citydb-tool-1.3.2/citydb --version); exec bash"]

--- a/internal/db/setup.go
+++ b/internal/db/setup.go
@@ -95,6 +95,10 @@ func RunCity2TabulaDBSetup(config *config.Config, conn *pgxpool.Pool) error {
 
 // ResetCity2TabulaSchemas drops the city2tabula and tabula schemas and rebuilds them from scratch.
 // Use this when you want to re-run the City2TABULA setup without touching CityDB.
+//
+// RunCity2TabulaDBSetup only (re)creates the tabula.tabula and city2tabula.tabula_variant
+// table shells; it does not reload the TABULA CSV. Without re-importing here, both tables
+// are left empty and every building's tabula_variant_code stays NULL after -extract-features.
 func ResetCity2TabulaSchemas(config *config.Config, conn *pgxpool.Pool) error {
 	schemas := []string{config.DB.Schemas.City2Tabula, config.DB.Schemas.Tabula}
 	for _, schema := range schemas {
@@ -102,7 +106,10 @@ func ResetCity2TabulaSchemas(config *config.Config, conn *pgxpool.Pool) error {
 			utils.Warn.Printf("Warning dropping schema %s: %v", schema, err)
 		}
 	}
-	return RunCity2TabulaDBSetup(config, conn)
+	if err := RunCity2TabulaDBSetup(config, conn); err != nil {
+		return err
+	}
+	return importer.ImportSupplementaryData(conn, config)
 }
 
 // setupMainDB runs the main DB setup job queue: PostgreSQL functions and main table schemas.


### PR DESCRIPTION
## Summary
- Bump citydb-tool from 1.1.0 to 1.3.2 in the Docker environment.
- `ResetCity2TabulaSchemas` (`-reset-db`) now re-imports the TABULA CSV after recreating `tabula.tabula`/`city2tabula.tabula_variant`, fixing every building's `tabula_variant_code` staying NULL after a reset + `-extract-features`.
- Document `ROOM_HEIGHT` in `.env.example` — the default room height (m) used for buildings missing height data in the source CityGML.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Run `-reset-db` followed by `-extract-features` against a test DB and confirm `tabula_variant_code` is populated (not NULL)