### PR TITLE
fix: round aggregate attributes to 2 decimals, insert missing columns

### DIFF
--- a/sql/scripts/main/03_calc_child_feat_attr.sql
+++ b/sql/scripts/main/03_calc_child_feat_attr.sql
@@ -214,14 +214,19 @@ SELECT
     -- (crossing sub-regions cancel). ST_MakeValid decomposes them into valid
     -- sub-polygons so ST_Area sums correctly. Called only for invalid surfaces;
     -- ST_IsValid is CSE'd with the is_valid column below (one evaluation per row).
-    CASE
-      WHEN objectclass_id IN (709, 710, 712)
-        THEN {city2tabula_schema}.surface_area_corrected_geom(valid_geom, nx, ny, nz)
-      ELSE NULL
-    END AS surface_area,
+    -- Rounded to 2 decimals (cm-level for lengths, cm² for areas) at the point of
+    -- computation — matches the ±0.04 m/° accuracy already validated against
+    -- reference data, so further digits are float noise, not real precision.
+    ROUND(
+      (CASE
+        WHEN objectclass_id IN (709, 710, 712)
+          THEN {city2tabula_schema}.surface_area_corrected_geom(valid_geom, nx, ny, nz)
+        ELSE NULL
+      END)::numeric, 2
+    ) AS surface_area,
     'sqm' AS surface_area_unit,
     -- ASIN(|nz|): 0° for vertical wall (nz=0), 90° for flat roof (|nz|=1).
-    DEGREES(ASIN(ABS(nz))) AS tilt,
+    ROUND(DEGREES(ASIN(ABS(nz)))::numeric, 2) AS tilt,
     'degrees' AS tilt_unit,
     -- (450 − atan2(ny, nx)) mod 360 converts math convention (CCW from east)
     -- to compass convention (CW from grid north). Suppressed (−1) when |nz| > 0.985
@@ -229,17 +234,19 @@ SELECT
     -- convergence_deg corrects grid north → geographic north (currently 0°; see Discussion).
     CASE
       WHEN ABS(nz) > 0.985 THEN -1
-      ELSE MOD(
-        MOD((450.0 - degrees(atan2(ny::numeric, nx::numeric)))::numeric + 360.0, 360.0)
-        + convergence_deg::numeric + 360.0,
-        360.0
+      ELSE ROUND(
+        MOD(
+          MOD((450.0 - degrees(atan2(ny::numeric, nx::numeric)))::numeric + 360.0, 360.0)
+          + convergence_deg::numeric + 360.0,
+          360.0
+        ), 2
       )
     END AS azimuth,
     'degrees' AS azimuth_unit,
     ST_IsValid(valid_geom) AS is_valid,
     is_planar,
     child_row_id,
-    (ST_ZMax(valid_geom) - ST_ZMin(valid_geom)) AS height,
+    ROUND((ST_ZMax(valid_geom) - ST_ZMin(valid_geom))::numeric, 2) AS height,
     'm',
     valid_geom AS geom
 FROM convergence_corrected;

--- a/sql/scripts/main/04_calc_bld_feat.sql
+++ b/sql/scripts/main/04_calc_bld_feat.sql
@@ -26,7 +26,10 @@ aggregated_surfaces AS (
         0 as construction_year,
         0.0 as heating_demand,
         'kWh/m2a' AS heating_demand_unit,
-        SUM(surface_area) FILTER (WHERE classname = 'GroundSurface') AS footprint_area,
+        -- Rounded to 2 decimals: inputs are already 2-decimal (script 03), but
+        -- SUM/addition of several such values can reintroduce float noise past
+        -- the 2nd decimal, so every aggregate below is rounded again on the way out.
+        ROUND(SUM(surface_area) FILTER (WHERE classname = 'GroundSurface')::numeric, 2) AS footprint_area,
         -- Footprint complexity: vertex count of the merged ground boundary.
         -- ≤ 4 vertices → simple rectangle; 5–10 → regular polygon; > 10 → complex shape.
         CASE
@@ -44,11 +47,11 @@ aggregated_surfaces AS (
         FALSE AS has_attached_neighbour,
         ARRAY[]::INTEGER[] AS attached_neighbour_id,
         0 AS total_attached_neighbour,
-        SUM(CASE WHEN classname = 'RoofSurface' THEN surface_area ELSE 0 END) AS area_total_roof,
+        ROUND(SUM(CASE WHEN classname = 'RoofSurface' THEN surface_area ELSE 0 END)::numeric, 2) AS area_total_roof,
         'sqm' AS area_total_roof_unit,
-        SUM(CASE WHEN classname = 'WallSurface' THEN surface_area ELSE 0 END) AS area_total_wall,
+        ROUND(SUM(CASE WHEN classname = 'WallSurface' THEN surface_area ELSE 0 END)::numeric, 2) AS area_total_wall,
         'sqm' AS area_total_wall_unit,
-        SUM(CASE WHEN classname = 'GroundSurface' THEN surface_area ELSE 0 END) AS area_total_floor,
+        ROUND(SUM(CASE WHEN classname = 'GroundSurface' THEN surface_area ELSE 0 END)::numeric, 2) AS area_total_floor,
         'sqm' AS area_total_floor_unit,
         COUNT(*) FILTER (WHERE classname = 'RoofSurface') AS surface_count_roof,
         COUNT(*) FILTER (WHERE classname = 'WallSurface') AS surface_count_wall,
@@ -57,8 +60,8 @@ aggregated_surfaces AS (
         MAX(height) FILTER (WHERE classname = 'WallSurface') AS min_height,
         'm' AS min_height_unit,
         -- Ridge height: eave height + max vertical span across all roof faces.
-        MAX(height) FILTER (WHERE classname = 'WallSurface') +
-        COALESCE(MAX(height) FILTER (WHERE classname = 'RoofSurface'), 0) AS max_height,
+        ROUND((MAX(height) FILTER (WHERE classname = 'WallSurface') +
+        COALESCE(MAX(height) FILTER (WHERE classname = 'RoofSurface'), 0))::numeric, 2) AS max_height,
         'm' AS max_height_unit,
         2.5 AS room_height,
         'm' AS room_height_unit,
@@ -85,6 +88,9 @@ INSERT INTO {city2tabula_schema}.{lod_schema}_building (
     object_id,
     country_code,
     building_feature_id,
+    construction_year,
+    heating_demand,
+    heating_demand_unit,
     footprint_area,
     footprint_complexity,
     roof_complexity,
@@ -115,6 +121,9 @@ SELECT
     object_id,
     '{country_code}'  AS country_code,
     building_feature_id,
+    construction_year,
+    heating_demand,
+    heating_demand_unit,
     footprint_area,
     footprint_complexity,
     roof_complexity,

--- a/sql/scripts/main/05_calc_volume.sql
+++ b/sql/scripts/main/05_calc_volume.sql
@@ -5,12 +5,12 @@ SET
     -- Volume calculations
     min_volume = CASE
         WHEN bf.min_height IS NOT NULL AND bf.footprint_area IS NOT NULL
-        THEN bf.min_height * bf.footprint_area
+        THEN ROUND((bf.min_height * bf.footprint_area)::numeric, 2)
         ELSE bf.min_volume
     END,
     max_volume = CASE
         WHEN bf.max_height IS NOT NULL AND bf.footprint_area IS NOT NULL
-        THEN bf.max_height * bf.footprint_area
+        THEN ROUND((bf.max_height * bf.footprint_area)::numeric, 2)
         ELSE bf.max_volume
     END,
     min_volume_unit = CASE

--- a/sql/scripts/main/06_calc_storeys.sql
+++ b/sql/scripts/main/06_calc_storeys.sql
@@ -17,6 +17,6 @@ SET
         THEN 'm'
         ELSE bf.room_height_unit
     END,
-    area_total_floor = bf.footprint_area * bf.number_of_storeys,
+    area_total_floor = ROUND((bf.footprint_area * bf.number_of_storeys)::numeric, 2),
     area_total_floor_unit = 'sqm'
 WHERE bf.building_feature_id IN {building_ids};


### PR DESCRIPTION
- Round surface_area/tilt/azimuth/height (03) and footprint_area, area_total_roof/wall/floor, max_height, volume (04/05/06) to 2 decimals. Raw floating-point aggregation was producing 10+ digit values with no real precision behind them.
- 04_calc_bld_feat.sql computed construction_year, heating_demand, and heating_demand_unit in its CTE but never included them in the INSERT column list, so all three silently stayed NULL for every building from creation onward.