### PR TITLE
chore: upload integration-test coverage to Codecov

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,6 +29,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
             token: ${{ secrets.CODECOV_TOKEN }}
+            flags: unit
 
   integration:
     name: Integration Tests
@@ -47,4 +48,10 @@ jobs:
         run: sudo apt-get install -y postgresql-client
 
       - name: Integration Tests
-        run: go test -tags integration -v -timeout 10m ./internal/process/
+        run: go test -tags integration -v -timeout 10m -coverprofile=coverage.out -covermode=atomic ./internal/process/
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            flags: integration


### PR DESCRIPTION
## Summary
Prompted by #87's patch coverage showing 25% despite the new code being thoroughly covered by integration tests — Codecov was only ever seeing the `unit` job's plain `go test ./...` run, never the `integration` job's Docker-based `go test -tags integration ./internal/process/`. Any DB-dependent code (most of `internal/process`) will always under-report on Codecov until this is fixed, regardless of actual test depth.

- Adds `-coverprofile`/`-covermode=atomic` to the integration test run
- Uploads it to Codecov under an `integration` flag, alongside the existing `unit` flag on the other job, so the combined report reflects both

## Test plan
- [x] `go test -tags integration -v -timeout 10m -coverprofile=... -covermode=atomic ./internal/process/` runs clean locally and produces a valid coverage profile
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Confirm on this PR's own CI run that both `unit` and `integration` flags appear in the Codecov report