### PR TITLE
refactor: remove unused heating_demand column

### DIFF
--- a/docs/code/sql-pipeline/04-building-features.md
+++ b/docs/code/sql-pipeline/04-building-features.md
@@ -132,7 +132,6 @@ Several columns are set to placeholder values that are not yet available at this
 | Column | Initial value | Updated by |
 |--------|--------------|-----------|
 | `construction_year` | 0 | External data (not automated) |
-| `heating_demand` | 0.0 | External energy model |
 | `has_attached_neighbour` | `FALSE` | Not yet implemented |
 | `surface_count_floor` | 0 | Not computed (ground is counted differently) |
 | `area_total_floor` | `= footprint_area` | Script 06 (overwritten) |

--- a/sql/schema/main/01_create_main_tables.sql
+++ b/sql/schema/main/01_create_main_tables.sql
@@ -71,8 +71,6 @@ CREATE TABLE {city2tabula_schema}.{lod_schema}_building (
   tabula_variant_code VARCHAR,
   construction_year INTEGER,
   comment TEXT,
-  heating_demand DOUBLE PRECISION,
-  heating_demand_unit VARCHAR(20) CHECK (heating_demand_unit IN ('kWh/m2a')),
   footprint_area DOUBLE PRECISION,
   footprint_complexity INTEGER CHECK (footprint_complexity IN (0, 1, 2)),
   roof_complexity INTEGER CHECK (roof_complexity IN (0, 1, 2)),

--- a/sql/scripts/main/04_calc_bld_feat.sql
+++ b/sql/scripts/main/04_calc_bld_feat.sql
@@ -24,8 +24,6 @@ aggregated_surfaces AS (
         cfs.building_feature_id,
         MIN(cfs.building_object_id) AS object_id,
         0 as construction_year,
-        0.0 as heating_demand,
-        'kWh/m2a' AS heating_demand_unit,
         -- Rounded to 2 decimals: inputs are already 2-decimal (script 03), but
         -- SUM/addition of several such values can reintroduce float noise past
         -- the 2nd decimal, so every aggregate below is rounded again on the way out.
@@ -89,8 +87,6 @@ INSERT INTO {city2tabula_schema}.{lod_schema}_building (
     country_code,
     building_feature_id,
     construction_year,
-    heating_demand,
-    heating_demand_unit,
     footprint_area,
     footprint_complexity,
     roof_complexity,
@@ -122,8 +118,6 @@ SELECT
     '{country_code}'  AS country_code,
     building_feature_id,
     construction_year,
-    heating_demand,
-    heating_demand_unit,
     footprint_area,
     footprint_complexity,
     roof_complexity,


### PR DESCRIPTION
## Summary
`heating_demand`/`heating_demand_unit` on `{lod_schema}_building` were always written as hardcoded placeholders (`0.0`, `'kWh/m2a'`) at INSERT time in script 04 and never read or updated anywhere else — heat demand is computed downstream (ignis), not stored in this table. Removes the dead columns from the schema, the extraction script, and the docs table that lists placeholder columns.

Confirmed no other references anywhere in the repo (`grep -rn heating_demand`), and no reference in `cityviz` (the only sibling repo checked locally that reads this schema).

No migration needed — schema changes here are picked up by the next `-reset-db`/`-create-db` (destructive recreate), same as the rest of `sql/schema/main/`.

## Test plan
- [x] `go build ./...`, `go vet ./...` (both with and without `-tags integration`)
- [x] `go test -tags integration -timeout 15m ./internal/process/...` — full pipeline (Germany/Austria/Netherlands fixtures) runs clean end to end without the column