### PR TITLE
test: guard footprint trigger against pg_dump/restore round trip

### DIFF
--- a/internal/process/correction_triggers_dumprestore_test.go
+++ b/internal/process/correction_triggers_dumprestore_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+package process_test
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/thd-spatial-ai/city2tabula/internal/config"
+)
+
+// dumpAndRestoreCity2TabulaSchema replicates the export/import round trip used to share a
+// corrected dataset between machines (heat-demand-models/export-data.sh): pg_dump the
+// city2tabula schema, drop it, then pg_restore. Trigger DDL replayed during restore runs
+// under the search_path pg_dump recorded for the dump (city2tabula only, not public),
+// which is what silently dropped the footprint-geometry trigger before it was fixed to use
+// schema-qualified public.ST_Equals instead of the search_path-dependent IS DISTINCT FROM.
+func dumpAndRestoreCity2TabulaSchema(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	dumpPath := filepath.Join(t.TempDir(), "city2tabula.dump")
+
+	dump := exec.Command("pg_dump", "-Fc", "--schema="+config.City2TabulaSchema, testConnStr, "-f", dumpPath)
+	if out, err := dump.CombinedOutput(); err != nil {
+		t.Fatalf("pg_dump failed: %v\noutput:\n%s", err, out)
+	}
+
+	if _, err := testPool.Exec(ctx, "DROP SCHEMA "+config.City2TabulaSchema+" CASCADE"); err != nil {
+		t.Fatalf("failed to drop %s schema before restore: %v", config.City2TabulaSchema, err)
+	}
+
+	restore := exec.Command("pg_restore", "-d", testConnStr, dumpPath)
+	out, err := restore.CombinedOutput()
+	// pg_restore exits non-zero on any warning (including the ambiguous-operator error this
+	// test guards against), so a restore this test relies on failing loudly is the point —
+	// don't swallow it as a soft warning.
+	if err != nil {
+		t.Fatalf("pg_restore reported errors: %v\noutput:\n%s", err, out)
+	}
+}
+
+// TestFootprintGeomTrigger_SurvivesDumpRestore guards the bug from work-tasks#19 /
+// city2tabula#82: the footprint-geometry correction trigger must still fire correctly
+// after the schema has been through a pg_dump --schema=city2tabula / pg_restore round
+// trip, not just on a freshly created database (which is all
+// TestFootprintGeomTrigger_RecomputesDerivedAttributes proves).
+func TestFootprintGeomTrigger_SurvivesDumpRestore(t *testing.T) {
+	_, buildingID := setupCorrectionAuditFixture(t)
+	ctx := context.Background()
+
+	before := readBuildingDims(t, ctx, buildingID)
+
+	dumpAndRestoreCity2TabulaSchema(t)
+
+	if _, err := testPool.Exec(ctx, `
+		UPDATE city2tabula.lod2_building
+		SET building_footprint_geom = ST_Multi(ST_Force3D(ST_MakeEnvelope(0, 0, 10, 10, 25832)))
+		WHERE id = $1`, buildingID,
+	); err != nil {
+		t.Fatalf("failed to apply footprint correction after restore: %v", err)
+	}
+
+	var footprintArea float64
+	var footprintComplexity int
+	if err := testPool.QueryRow(ctx,
+		`SELECT footprint_area, footprint_complexity FROM city2tabula.lod2_building WHERE id = $1`,
+		buildingID,
+	).Scan(&footprintArea, &footprintComplexity); err != nil {
+		t.Fatalf("failed to read recomputed building after restore: %v", err)
+	}
+
+	if !almostEqual(footprintArea, 100.0) {
+		t.Errorf("trigger did not fire after dump/restore: expected footprint_area = 100.00 (10x10 square), got %v (before update: %v) — trigger was likely dropped silently on restore",
+			footprintArea, before.footprintArea)
+	}
+	if footprintComplexity != 1 {
+		t.Errorf("trigger did not fire after dump/restore: expected footprint_complexity = 1, got %d", footprintComplexity)
+	}
+}

--- a/internal/process/correction_triggers_dumprestore_test.go
+++ b/internal/process/correction_triggers_dumprestore_test.go
@@ -3,13 +3,42 @@
 package process_test
 
 import (
+	"bytes"
 	"context"
-	"os/exec"
-	"path/filepath"
 	"testing"
 
+	tcexec "github.com/testcontainers/testcontainers-go/exec"
 	"github.com/thd-spatial-ai/city2tabula/internal/config"
 )
+
+// pgEnv authenticates pg_dump/pg_restore inside the container the same way the test DB
+// itself was configured in TestMain (POSTGRES_USER=test, POSTGRES_PASSWORD=test).
+var pgEnv = []string{"PGPASSWORD=test"}
+
+// execInContainer runs a command inside the running PostGIS container (rather than on the
+// host) so pg_dump/pg_restore always match the server's own version — a host-installed
+// client can be older or newer than the container's Postgres and refuse to run, which is
+// exactly what happened the first time this test ran in CI (client 16.14 vs. server 17.0).
+func execInContainer(t *testing.T, cmd []string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	exitCode, reader, err := testContainer.Exec(ctx, cmd, tcexec.WithEnv(pgEnv))
+	if err != nil {
+		t.Fatalf("failed to exec %v in container: %v", cmd, err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(reader); err != nil {
+		t.Fatalf("failed to read output of %v: %v", cmd, err)
+	}
+	output := buf.String()
+
+	if exitCode != 0 {
+		t.Fatalf("%v exited %d:\n%s", cmd, exitCode, output)
+	}
+	return output
+}
 
 // dumpAndRestoreCity2TabulaSchema replicates the export/import round trip used to share a
 // corrected dataset between machines (heat-demand-models/export-data.sh): pg_dump the
@@ -21,25 +50,23 @@ func dumpAndRestoreCity2TabulaSchema(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
 
-	dumpPath := filepath.Join(t.TempDir(), "city2tabula.dump")
+	const dumpPath = "/tmp/city2tabula.dump"
 
-	dump := exec.Command("pg_dump", "-Fc", "--schema="+config.City2TabulaSchema, testConnStr, "-f", dumpPath)
-	if out, err := dump.CombinedOutput(); err != nil {
-		t.Fatalf("pg_dump failed: %v\noutput:\n%s", err, out)
-	}
+	execInContainer(t, []string{
+		"pg_dump", "-h", "localhost", "-U", "test", "-d", "city2tabula_test",
+		"-Fc", "--schema=" + config.City2TabulaSchema, "-f", dumpPath,
+	})
 
 	if _, err := testPool.Exec(ctx, "DROP SCHEMA "+config.City2TabulaSchema+" CASCADE"); err != nil {
 		t.Fatalf("failed to drop %s schema before restore: %v", config.City2TabulaSchema, err)
 	}
 
-	restore := exec.Command("pg_restore", "-d", testConnStr, dumpPath)
-	out, err := restore.CombinedOutput()
-	// pg_restore exits non-zero on any warning (including the ambiguous-operator error this
+	// pg_restore exits non-zero on any error (including the ambiguous-operator error this
 	// test guards against), so a restore this test relies on failing loudly is the point —
-	// don't swallow it as a soft warning.
-	if err != nil {
-		t.Fatalf("pg_restore reported errors: %v\noutput:\n%s", err, out)
-	}
+	// execInContainer treats that as a hard failure rather than a swallowed warning.
+	execInContainer(t, []string{
+		"pg_restore", "-h", "localhost", "-U", "test", "-d", "city2tabula_test", dumpPath,
+	})
 }
 
 // TestFootprintGeomTrigger_SurvivesDumpRestore guards the bug from work-tasks#19 /

--- a/internal/process/integration_test.go
+++ b/internal/process/integration_test.go
@@ -26,6 +26,11 @@ var testPool *pgxpool.Pool
 // testConnStr holds the DSN for psql-based seed execution (COPY FROM stdin requires psql).
 var testConnStr string
 
+// testContainer is the running PostGIS container, exposed so tests that need pg_dump/
+// pg_restore can exec them inside it — guarantees a version match with the server
+// regardless of what (if anything) is installed on the host running `go test`.
+var testContainer testcontainers.Container
+
 func TestMain(m *testing.M) {
 	// SQL script paths in config are relative to the project root.
 	// Tests run from the package directory (internal/process/), so we go up two levels.
@@ -54,6 +59,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("failed to start PostGIS container: %v", err)
 	}
 	defer container.Terminate(ctx)
+	testContainer = container
 
 	host, err := container.Host(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary
Regression test for #82 / work-tasks#19: the footprint-geometry correction trigger's old `WHEN` clause used a bare `IS DISTINCT FROM` on a geometry column, which resolves PostGIS's `=` operator through `search_path` — fine on a live connection, but `pg_dump --schema=city2tabula` / `pg_restore` replays trigger DDL under only the dumped schema's own `search_path`, silently dropping the trigger. #82 fixed this (schema-qualified `public.ST_Equals`), but nothing exercised the actual dump/restore path — every other trigger test only ever runs against a freshly created schema.

This test dumps `city2tabula`, drops it, restores it, then confirms the footprint trigger still fires correctly afterward.

## Test plan
- [x] `go test -tags integration -v -timeout 5m -run TestFootprintGeomTrigger_SurvivesDumpRestore ./internal/process/` — passes against a real PostGIS container with actual `pg_dump`/`pg_restore`