### PR TITLE
test: cover internal/db and internal/importer, fix two real bugs found along the way

### DIFF
--- a/internal/db/citydb_test.go
+++ b/internal/db/citydb_test.go
@@ -1,0 +1,52 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/thd-spatial-ai/city2tabula/internal/config"
+)
+
+func TestParseSRID(t *testing.T) {
+	cases := []struct {
+		name    string
+		crs     string
+		want    int
+		wantErr bool
+	}{
+		{"bare number", "25832", 25832, false},
+		{"EPSG prefix", "EPSG:25832", 25832, false},
+		{"lowercase epsg prefix", "epsg:25832", 25832, false},
+		{"mixed case prefix", "Epsg:25832", 25832, false},
+		{"surrounding whitespace", "  25832  ", 25832, false},
+		{"whitespace with prefix", " EPSG:31256 ", 31256, false},
+		{"non-numeric", "not-a-code", 0, true},
+		{"empty string", "", 0, true},
+		{"zero", "0", 0, true},
+		{"negative", "-25832", 0, true},
+		{"prefix with no number", "EPSG:", 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSRID(tc.crs)
+
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseSRID(%q) error = %v, wantErr %v", tc.crs, err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("parseSRID(%q) = %d, want %d", tc.crs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecuteCityDBScript_MissingScriptReturnsErrorWithoutTouchingDB(t *testing.T) {
+	cfg := &config.Config{
+		DB: &config.DBConfig{Host: "127.0.0.1", Port: "9999", Name: "nonexistent", User: "nobody", Password: "wrong"},
+	}
+
+	err := ExecuteCityDBScript(cfg, "/nonexistent/script/path.sql", "lod2")
+	if err == nil {
+		t.Fatal("expected an error for a missing script path, got nil")
+	}
+}

--- a/internal/db/connection.go
+++ b/internal/db/connection.go
@@ -86,7 +86,6 @@ func ConnectPool(config *config.Config) (*pgxpool.Pool, error) {
 
 // create extensions in the *current* DB (the one dsn points to)
 func enablePostgis(ctx context.Context, pool *pgxpool.Pool, config *config.Config) error {
-	pool.Exec(ctx, `PostgreSQL version: `) // dummy to ensure connection is alive
 	if _, err := pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS postgis`); err != nil {
 		return fmt.Errorf("failed to enable PostGIS: %w", err)
 	}

--- a/internal/db/db_integration_test.go
+++ b/internal/db/db_integration_test.go
@@ -1,0 +1,287 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"github.com/thd-spatial-ai/city2tabula/internal/config"
+	"github.com/thd-spatial-ai/city2tabula/internal/db"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// testHost/testPort point at the bootstrap "postgres" database in the container;
+// each test builds its own *config.Config from these so EnsureDatabase/ConnectPool
+// (the functions under test) are the only thing creating/opening the target DB.
+var (
+	testHost string
+	testPort string
+)
+
+// testPool is a shared connection, opened once via db.ConnectPool against a
+// dedicated test database, for tests that only need a working pool (schema
+// create/drop, ListCityDBSchemas) rather than testing connection setup itself.
+var testPool *pgxpool.Pool
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image: "postgis/postgis:17-3.4",
+		Env: map[string]string{
+			"POSTGRES_DB":       "postgres",
+			"POSTGRES_USER":     "test",
+			"POSTGRES_PASSWORD": "test",
+		},
+		ExposedPorts: []string{"5432/tcp"},
+		WaitingFor:   wait.ForLog("database system is ready to accept connections").AsRegexp(),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		log.Fatalf("failed to start PostGIS container: %v", err)
+	}
+	defer container.Terminate(ctx)
+
+	testHost, err = container.Host(ctx)
+	if err != nil {
+		log.Fatalf("failed to get container host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "5432")
+	if err != nil {
+		log.Fatalf("failed to get container port: %v", err)
+	}
+	testPort = port.Port()
+
+	// PostGIS images do extra initialization after the "ready" log line. Ping until
+	// PostgreSQL is truly accepting connections (up to 15 seconds) before the tests'
+	// own db.ConnectPool call, which would otherwise race that restart.
+	if err := waitForBootstrapDB(ctx); err != nil {
+		log.Fatalf("PostgreSQL not ready: %v", err)
+	}
+
+	pool, err := db.ConnectPool(testConfig("citytabula_dbtest"))
+	if err != nil {
+		log.Fatalf("failed to connect shared test pool: %v", err)
+	}
+	testPool = pool
+	defer db.ClosePool(testPool)
+
+	os.Exit(m.Run())
+}
+
+// waitForBootstrapDB pings the bootstrap "postgres" database until it accepts
+// connections or 15 seconds pass, mirroring internal/process/integration_test.go's
+// TestMain (same PostGIS image, same post-"ready"-log restart to wait out).
+func waitForBootstrapDB(ctx context.Context) error {
+	bootstrapDSN := fmt.Sprintf("host=%s port=%s user=test password=test dbname=postgres sslmode=disable", testHost, testPort)
+	pool, err := pgxpool.New(ctx, bootstrapDSN)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+
+	var lastErr error
+	for i := 0; i < 30; i++ {
+		if lastErr = pool.Ping(ctx); lastErr == nil {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return lastErr
+}
+
+// testConfig builds the minimal *config.Config the functions under test need:
+// connection details plus the two schema names ListCityDBSchemas filters on.
+func testConfig(dbName string) *config.Config {
+	return &config.Config{
+		DB: &config.DBConfig{
+			Host:     testHost,
+			Port:     testPort,
+			Name:     dbName,
+			User:     "test",
+			Password: "test",
+			SSLMode:  "disable",
+			Schemas: &config.Schemas{
+				Lod2: "lod2",
+				Lod3: "lod3",
+			},
+		},
+		Batch: &config.BatchConfig{Threads: 2},
+	}
+}
+
+func TestEnsureDatabase_CreatesDatabaseIfMissing(t *testing.T) {
+	cfg := testConfig("ensure_db_test")
+
+	if err := db.EnsureDatabase(cfg); err != nil {
+		t.Fatalf("EnsureDatabase (create): %v", err)
+	}
+
+	exists, err := databaseExists(t, cfg.DB.Name)
+	if err != nil {
+		t.Fatalf("failed to check database existence: %v", err)
+	}
+	if !exists {
+		t.Fatalf("expected database %q to exist after EnsureDatabase, it does not", cfg.DB.Name)
+	}
+
+	// Idempotent: calling it again against an already-existing database must not error.
+	if err := db.EnsureDatabase(cfg); err != nil {
+		t.Fatalf("EnsureDatabase (already exists): %v", err)
+	}
+}
+
+func databaseExists(t *testing.T, name string) (bool, error) {
+	t.Helper()
+	bootstrapDSN := fmt.Sprintf("host=%s port=%s user=test password=test dbname=postgres sslmode=disable", testHost, testPort)
+	conn, err := pgxpool.New(context.Background(), bootstrapDSN)
+	if err != nil {
+		return false, err
+	}
+	defer conn.Close()
+
+	var exists bool
+	err = conn.QueryRow(context.Background(),
+		`SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname = $1)`, name,
+	).Scan(&exists)
+	return exists, err
+}
+
+func TestConnectPool_ConnectsAndEnablesPostGIS(t *testing.T) {
+	cfg := testConfig("connect_pool_test")
+
+	pool, err := db.ConnectPool(cfg)
+	if err != nil {
+		t.Fatalf("ConnectPool: %v", err)
+	}
+	defer db.ClosePool(pool)
+
+	var version string
+	if err := pool.QueryRow(context.Background(), `SELECT PostGIS_Version()`).Scan(&version); err != nil {
+		t.Errorf("expected PostGIS to be enabled on the connected database, PostGIS_Version() failed: %v", err)
+	}
+}
+
+func TestCreateAndDropSchemaIfNotExists_AreIdempotent(t *testing.T) {
+	ctx := context.Background()
+	const schema = "create_drop_idempotent_test"
+	defer testPool.Exec(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+
+	if err := db.CreateSchemaIfNotExists(testPool, schema); err != nil {
+		t.Fatalf("CreateSchemaIfNotExists (1st): %v", err)
+	}
+	if err := db.CreateSchemaIfNotExists(testPool, schema); err != nil {
+		t.Fatalf("CreateSchemaIfNotExists (2nd, already exists): %v", err)
+	}
+	if !schemaExists(t, ctx, schema) {
+		t.Fatalf("expected schema %q to exist after CreateSchemaIfNotExists", schema)
+	}
+
+	if err := db.DropSchemaIfExists(testPool, schema); err != nil {
+		t.Fatalf("DropSchemaIfExists (1st): %v", err)
+	}
+	if err := db.DropSchemaIfExists(testPool, schema); err != nil {
+		t.Fatalf("DropSchemaIfExists (2nd, already gone): %v", err)
+	}
+	if schemaExists(t, ctx, schema) {
+		t.Fatalf("expected schema %q to be gone after DropSchemaIfExists", schema)
+	}
+}
+
+func schemaExists(t *testing.T, ctx context.Context, name string) bool {
+	t.Helper()
+	var exists bool
+	if err := testPool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1)`, name,
+	).Scan(&exists); err != nil {
+		t.Fatalf("failed to check schema existence for %q: %v", name, err)
+	}
+	return exists
+}
+
+func TestCreateSchemas_CreatesEveryListedSchema(t *testing.T) {
+	ctx := context.Background()
+	schemas := []string{"batch_create_a_test", "batch_create_b_test"}
+	defer func() {
+		for _, s := range schemas {
+			testPool.Exec(ctx, `DROP SCHEMA IF EXISTS `+s+` CASCADE`)
+		}
+	}()
+
+	if err := db.CreateSchemas(testPool, schemas); err != nil {
+		t.Fatalf("CreateSchemas: %v", err)
+	}
+	for _, s := range schemas {
+		if !schemaExists(t, ctx, s) {
+			t.Errorf("expected schema %q to exist after CreateSchemas", s)
+		}
+	}
+}
+
+func TestDropCity2TabulaSchemas_DropsEveryListedSchema(t *testing.T) {
+	ctx := context.Background()
+	schemas := []string{"batch_drop_a_test", "batch_drop_b_test"}
+	if err := db.CreateSchemas(testPool, schemas); err != nil {
+		t.Fatalf("failed to seed schemas to drop: %v", err)
+	}
+
+	if err := db.DropCity2TabulaSchemas(testPool, schemas); err != nil {
+		t.Fatalf("DropCity2TabulaSchemas: %v", err)
+	}
+	for _, s := range schemas {
+		if schemaExists(t, ctx, s) {
+			t.Errorf("expected schema %q to be gone after DropCity2TabulaSchemas", s)
+		}
+	}
+}
+
+// TestListCityDBSchemas_FindsConfiguredAndCitydbLikeSchemas guards against the bug
+// where the query was built via fmt.Sprintf (schema names already inlined, no
+// placeholders) while conn.Query was still called with those same two values as
+// extra positional args - pgx rejects a query with unused/mismatched arguments, so
+// this call failed outright before the fix. Now fixed to parameterize once.
+func TestListCityDBSchemas_FindsConfiguredAndCitydbLikeSchemas(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig("connect_pool_test") // Schemas.Lod2="lod2", Schemas.Lod3="lod3"
+
+	matching := []string{"lod2", "lod3", "citydb_pkg_list_test"}
+	unrelated := "unrelated_schema_list_test"
+	defer func() {
+		for _, s := range append(matching, unrelated) {
+			testPool.Exec(ctx, `DROP SCHEMA IF EXISTS `+s+` CASCADE`)
+		}
+	}()
+	if err := db.CreateSchemas(testPool, append(matching, unrelated)); err != nil {
+		t.Fatalf("failed to seed schemas: %v", err)
+	}
+
+	got, err := db.ListCityDBSchemas(testPool, cfg)
+	if err != nil {
+		t.Fatalf("ListCityDBSchemas: %v", err)
+	}
+
+	gotSet := make(map[string]bool, len(got))
+	for _, s := range got {
+		gotSet[s] = true
+	}
+	for _, want := range matching {
+		if !gotSet[want] {
+			t.Errorf("expected ListCityDBSchemas to include %q, got %v", want, got)
+		}
+	}
+	if gotSet[unrelated] {
+		t.Errorf("expected ListCityDBSchemas to exclude %q, got %v", unrelated, got)
+	}
+}

--- a/internal/db/setup.go
+++ b/internal/db/setup.go
@@ -264,14 +264,12 @@ func DropSchemaIfExists(conn *pgxpool.Pool, schemaName string) error {
 
 // ListCityDBSchemas lists all existing CityDB-related schemas (for debugging)
 func ListCityDBSchemas(conn *pgxpool.Pool, config *config.Config) ([]string, error) {
-	query := fmt.Sprintf(
-		`SELECT schema_name
+	query := `SELECT schema_name
         FROM information_schema.schemata
-        WHERE schema_name LIKE '%%citydb%%'
-           OR schema_name = '%s'
-           OR schema_name = '%s'
-        ORDER BY schema_name;`,
-		config.DB.Schemas.Lod2, config.DB.Schemas.Lod3)
+        WHERE schema_name LIKE '%citydb%'
+           OR schema_name = $1
+           OR schema_name = $2
+        ORDER BY schema_name;`
 
 	rows, err := conn.Query(context.Background(), query, config.DB.Schemas.Lod2, config.DB.Schemas.Lod3)
 	if err != nil {

--- a/internal/importer/supplementary.go
+++ b/internal/importer/supplementary.go
@@ -2,6 +2,7 @@ package importer
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sync"
@@ -51,24 +52,10 @@ func ImportTabulaData(conn *pgxpool.Pool, config *config.Config) error {
 }
 
 func ImportCsvWithPsql(filePath string, config *config.Config) error {
-	// Convert to absolute path
-	absPath, err := filepath.Abs(filePath)
+	cmd, err := getCsvImportCommand(filePath, config)
 	if err != nil {
-		return fmt.Errorf("failed to get absolute path: %v", err)
+		return err
 	}
-
-	copyCommand := fmt.Sprintf("\\copy tabula.tabula FROM '%s' DELIMITER ',' CSV HEADER", absPath)
-
-	// Build psql command
-	cmd := exec.Command("psql",
-		"-h", config.DB.Host,
-		"-p", config.DB.Port,
-		"-U", config.DB.User,
-		"-d", config.DB.Name,
-		"-c", copyCommand)
-
-	// Set environment variables for psql
-	cmd.Env = append(cmd.Env, fmt.Sprintf("PGPASSWORD=%s", config.DB.Password))
 
 	// Capture both stdout and stderr for better debugging
 	output, err := cmd.CombinedOutput()
@@ -79,4 +66,29 @@ func ImportCsvWithPsql(filePath string, config *config.Config) error {
 
 	utils.Info.Printf("psql success: %s", string(output))
 	return nil
+}
+
+// getCsvImportCommand builds the psql \copy command that loads filePath into
+// tabula.tabula. Command construction is separated from execution so tests can
+// assert on the resulting *exec.Cmd (args, env) without actually running psql.
+func getCsvImportCommand(filePath string, config *config.Config) (*exec.Cmd, error) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path: %v", err)
+	}
+
+	copyCommand := fmt.Sprintf("\\copy tabula.tabula FROM '%s' DELIMITER ',' CSV HEADER", absPath)
+
+	cmd := exec.Command("psql",
+		"-h", config.DB.Host,
+		"-p", config.DB.Port,
+		"-U", config.DB.User,
+		"-d", config.DB.Name,
+		"-c", copyCommand)
+
+	// Inherit the current environment (PATH, HOME, locale, ...) rather than
+	// replacing it outright - psql needs more than just PGPASSWORD to run correctly.
+	cmd.Env = append(os.Environ(), fmt.Sprintf("PGPASSWORD=%s", config.DB.Password))
+
+	return cmd, nil
 }

--- a/internal/importer/supplementary_test.go
+++ b/internal/importer/supplementary_test.go
@@ -1,10 +1,91 @@
 package importer
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/thd-spatial-ai/city2tabula/internal/config"
 )
+
+func minimalSupplementaryConfig() *config.Config {
+	return &config.Config{
+		DB: &config.DBConfig{
+			Host:     "dbhost",
+			Port:     "5432",
+			Name:     "testdb",
+			User:     "user",
+			Password: "pass",
+		},
+	}
+}
+
+func TestGetCsvImportCommand_ArgsStructure(t *testing.T) {
+	// Given
+	cfg := minimalSupplementaryConfig()
+
+	// When
+	cmd, err := getCsvImportCommand("testdata/tabula.csv", cfg)
+	if err != nil {
+		t.Fatalf("getCsvImportCommand: %v", err)
+	}
+
+	// Then: connection flags reflect the config
+	args := strings.Join(cmd.Args, " ")
+	for _, want := range []string{"-h dbhost", "-p 5432", "-U user", "-d testdb"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("expected args to contain %q, got %q", want, args)
+		}
+	}
+
+	// Then: the \copy command targets tabula.tabula with an absolute path
+	if !strings.Contains(args, "\\copy tabula.tabula FROM") {
+		t.Errorf("expected a \\copy tabula.tabula command, got %q", args)
+	}
+	wd, _ := os.Getwd()
+	if !strings.Contains(args, wd) {
+		t.Errorf("expected the CSV path to be made absolute (containing %q), got %q", wd, args)
+	}
+}
+
+// TestGetCsvImportCommand_InheritsCurrentEnvironment guards against a bug where
+// cmd.Env was built as append(cmd.Env, "PGPASSWORD=...") starting from cmd's zero
+// value (nil) instead of os.Environ(). Per os/exec, a non-nil Env *replaces* the
+// child process's environment rather than extending it - so the psql subprocess
+// ran with only PGPASSWORD set and nothing else (no PATH, HOME, locale, ...).
+func TestGetCsvImportCommand_InheritsCurrentEnvironment(t *testing.T) {
+	// Given: a marker variable known to be in the current process's environment
+	t.Setenv("CITY2TABULA_TEST_ENV_MARKER", "present")
+	cfg := minimalSupplementaryConfig()
+
+	// When
+	cmd, err := getCsvImportCommand("testdata/tabula.csv", cfg)
+	if err != nil {
+		t.Fatalf("getCsvImportCommand: %v", err)
+	}
+
+	// Then: the marker survives into the command's environment
+	found := false
+	for _, e := range cmd.Env {
+		if e == "CITY2TABULA_TEST_ENV_MARKER=present" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected the current process's environment to be inherited, but the marker var is missing — cmd.Env likely replaced the environment instead of extending it")
+	}
+
+	// Then: PGPASSWORD is still set correctly on top of the inherited environment
+	wantPassword := false
+	for _, e := range cmd.Env {
+		if e == "PGPASSWORD=pass" {
+			wantPassword = true
+		}
+	}
+	if !wantPassword {
+		t.Error("expected PGPASSWORD=pass in cmd.Env")
+	}
+}
 
 func TestImportCsvWithPsql_ReturnsErrorOnFailure(t *testing.T) {
 	// Given: a config pointing at a non-existent database


### PR DESCRIPTION
## Summary
`internal/db` had zero test files; `internal/importer` had partial coverage. Auditing both surfaced two real, pre-existing bugs — both fixed here with regression tests that fail against the old code (verified locally by reverting each fix and re-running).

**Bugs found and fixed:**
- `ListCityDBSchemas` (`internal/db/setup.go`) built its query via `fmt.Sprintf` with the two schema names already inlined (no `$1`/`$2` placeholders), then called `conn.Query` with those same two values as extra positional args anyway — pgx rejects a query invoked with more arguments than placeholders, so every call failed outright. Fixed to parameterize once.
- `ImportCsvWithPsql` (`internal/importer/supplementary.go`): `cmd.Env = append(cmd.Env, "PGPASSWORD=...")` started from `cmd.Env`'s zero value (`nil`), not `os.Environ()`. A non-nil `Env` *replaces* the child process's environment rather than extending it, so the `psql` subprocess ran with only `PGPASSWORD` set — no `PATH`, `HOME`, locale, etc. — unlike `citydb.go`'s `executeCityDBScript`, which correctly starts from `os.Environ()`.

**Also removed:** a dead line in `enablePostgis` — `pool.Exec(ctx, "PostgreSQL version: ")` isn't valid SQL, always errors, and the error was discarded. Never did anything (`pool.Ping` right above it already verifies the connection).

**New coverage:**
- `internal/db`: 0% → 38.1%. `parseSRID` (100%) and `ExecuteCityDBScript`'s missing-file path as plain unit tests; `EnsureDatabase`, `ConnectPool`, the schema create/drop helpers, and `ListCityDBSchemas` via a new testcontainers-based integration suite (mirrors `internal/process`'s `TestMain` pattern).
- `internal/importer`: → 27.8%. `getCsvImportCommand` extracted from `ImportCsvWithPsql` (mirroring the existing `getCityDBImportCommand` pattern) so both arg construction and the environment-inheritance fix are unit-testable without running `psql`.

**Deliberately out of scope:** the remaining 0%-coverage functions in both packages (`CreateCityDB`, `ImportCityDBData`, etc.) shell out to the real CityDB Java CLI tool and require actual CityGML/CityJSON data — consistent with why `internal/process`'s own integration tests use pre-baked SQL dump fixtures instead of exercising that exact path.

## Test plan
- [x] `go test ./...` and `go vet ./...` (with and without `-tags integration`)
- [x] `go test -tags integration -timeout 15m ./internal/db/... ./internal/importer/... ./internal/process/...` — all pass against real Docker PostGIS containers
- [x] Both bug-fix regression tests manually verified to fail against the pre-fix code (reverted each fix locally, confirmed the corresponding test fails, then restored)