### PR TITLE
test: cover internal/utils (7.6% -> 96.2%)

### DIFF
--- a/internal/utils/exec.go
+++ b/internal/utils/exec.go
@@ -11,7 +11,7 @@ import (
 func ExecuteCommand(command string) error {
 	Info.Printf("Executing command: %s", command)
 	var cmd *exec.Cmd
-	if isWindows() {
+	if isWindows(runtime.GOOS) {
 		cmd = exec.Command("cmd", "/C", command)
 	} else {
 		cmd = exec.Command("sh", "-c", command)
@@ -27,6 +27,8 @@ func ExecuteCommand(command string) error {
 	return nil
 }
 
-func isWindows() bool {
-	return strings.Contains(strings.ToLower(runtime.GOOS), "windows")
+// isWindows takes runtime.GOOS as a parameter (rather than reading it directly)
+// so the decision logic is testable on any platform without cross-compiling.
+func isWindows(goos string) bool {
+	return strings.Contains(strings.ToLower(goos), "windows")
 }

--- a/internal/utils/exec_test.go
+++ b/internal/utils/exec_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsWindows(t *testing.T) {
+	cases := []struct {
+		goos string
+		want bool
+	}{
+		{"windows", true},
+		{"Windows", true},
+		{"WINDOWS", true},
+		{"linux", false},
+		{"darwin", false},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.goos, func(t *testing.T) {
+			if got := isWindows(tc.goos); got != tc.want {
+				t.Errorf("isWindows(%q) = %v, want %v", tc.goos, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecuteCommand_Success(t *testing.T) {
+	if err := ExecuteCommand("true"); err != nil {
+		t.Errorf("expected nil error for a command that exits 0, got %v", err)
+	}
+}
+
+func TestExecuteCommand_ReturnsErrorOnNonZeroExit(t *testing.T) {
+	err := ExecuteCommand("exit 1")
+	if err == nil {
+		t.Error("expected an error for a command that exits non-zero, got nil")
+	}
+}
+
+func TestExecuteCommand_IncludesOutputOnFailure(t *testing.T) {
+	err := ExecuteCommand("echo failure-marker && exit 1")
+	if err == nil {
+		t.Fatal("expected an error for a command that exits non-zero, got nil")
+	}
+	if got := err.Error(); !strings.Contains(got, "failure-marker") {
+		t.Errorf("expected error to include the command's output, got %q", got)
+	}
+}

--- a/internal/utils/logger_test.go
+++ b/internal/utils/logger_test.go
@@ -1,0 +1,139 @@
+package utils
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// restoreLoggerState saves the package-level logger vars and currentLogLevel, and
+// returns a func to restore them - these tests mutate global state (Info/Debug/
+// Warn/Error, currentLogLevel), which would otherwise leak between tests and into
+// any other test in this package that runs afterward in the same process.
+func restoreLoggerState(t *testing.T) {
+	t.Helper()
+	origInfo, origDebug, origWarn, origError := Info, Debug, Warn, Error
+	origLevel := currentLogLevel
+	t.Cleanup(func() {
+		Info, Debug, Warn, Error = origInfo, origDebug, origWarn, origError
+		currentLogLevel = origLevel
+	})
+}
+
+func TestSetLogLevelFromEnv(t *testing.T) {
+	restoreLoggerState(t)
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   LogLevel
+	}{
+		{name: "DEBUG", envVal: "DEBUG", want: LogLevelDebug},
+		{name: "INFO", envVal: "INFO", want: LogLevelInfo},
+		{name: "WARN", envVal: "WARN", want: LogLevelWarn},
+		{name: "WARNING", envVal: "WARNING", want: LogLevelWarn},
+		{name: "ERROR", envVal: "ERROR", want: LogLevelError},
+		{name: "lowercase debug", envVal: "debug", want: LogLevelDebug},
+		{name: "unknown value defaults to INFO", envVal: "NONSENSE", want: LogLevelInfo},
+		{name: "unset defaults to INFO", unset: true, want: LogLevelInfo},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				os.Unsetenv("LOG_LEVEL")
+			} else {
+				t.Setenv("LOG_LEVEL", tc.envVal)
+			}
+
+			setLogLevelFromEnv()
+
+			if currentLogLevel != tc.want {
+				t.Errorf("setLogLevelFromEnv() with LOG_LEVEL=%q: currentLogLevel = %v, want %v", tc.envVal, currentLogLevel, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetLogLevelName(t *testing.T) {
+	cases := []struct {
+		level LogLevel
+		want  string
+	}{
+		{LogLevelDebug, "DEBUG"},
+		{LogLevelInfo, "INFO"},
+		{LogLevelWarn, "WARN"},
+		{LogLevelError, "ERROR"},
+		{LogLevel(99), "UNKNOWN"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := getLogLevelName(tc.level); got != tc.want {
+				t.Errorf("getLogLevelName(%v) = %q, want %q", tc.level, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetLogLevel(t *testing.T) {
+	restoreLoggerState(t)
+
+	SetLogLevel(LogLevelError)
+
+	if got := GetLogLevel(); got != LogLevelError {
+		t.Errorf("GetLogLevel() = %v, want %v", got, LogLevelError)
+	}
+}
+
+func TestIsDebugEnabled(t *testing.T) {
+	restoreLoggerState(t)
+
+	SetLogLevel(LogLevelDebug)
+	if !IsDebugEnabled() {
+		t.Error("expected IsDebugEnabled() = true when level is Debug")
+	}
+
+	SetLogLevel(LogLevelInfo)
+	if IsDebugEnabled() {
+		t.Error("expected IsDebugEnabled() = false when level is Info")
+	}
+}
+
+// TestInitLogger_CreatesLogFileAndWritesToIt covers InitLogger's success path: a
+// fresh working directory (so "logs/" is created from scratch), LOG_LEVEL unset
+// (exercises the default-to-INFO branch), and confirms both the log file and the
+// package-level Info logger actually receive output afterward.
+func TestInitLogger_CreatesLogFileAndWritesToIt(t *testing.T) {
+	restoreLoggerState(t)
+	t.Chdir(t.TempDir())
+	os.Unsetenv("LOG_LEVEL")
+
+	InitLogger()
+
+	entries, err := os.ReadDir("logs")
+	if err != nil {
+		t.Fatalf("expected InitLogger to create a logs/ directory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 log file in logs/, got %d", len(entries))
+	}
+
+	logContent, err := os.ReadFile(filepath.Join("logs", entries[0].Name()))
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	if !strings.Contains(string(logContent), "Logger initialized with level: INFO") {
+		t.Errorf("expected log file to contain the init message, got: %s", logContent)
+	}
+
+	var buf bytes.Buffer
+	Info.SetOutput(&buf)
+	Info.Printf("marker line")
+	if !strings.Contains(buf.String(), "marker line") {
+		t.Error("expected Info logger to still be usable after InitLogger")
+	}
+}

--- a/internal/utils/print_test.go
+++ b/internal/utils/print_test.go
@@ -1,0 +1,105 @@
+package utils_test
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/thd-spatial-ai/city2tabula/internal/config"
+	"github.com/thd-spatial-ai/city2tabula/internal/utils"
+)
+
+// captureInfo swaps utils.Info for a fresh logger writing to a buffer, restoring
+// the original *log.Logger afterward. Using SetOutput on the shared logger instead
+// would mutate it in place, so saving/restoring the same pointer wouldn't undo
+// anything - the swap is what makes restoration actually work.
+func captureInfo(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := utils.Info
+	utils.Info = log.New(&buf, orig.Prefix(), orig.Flags())
+	t.Cleanup(func() { utils.Info = orig })
+	return &buf
+}
+
+func TestPrintTaskInfo(t *testing.T) {
+	t.Run("5 or fewer building IDs are all shown", func(t *testing.T) {
+		buf := captureInfo(t)
+
+		utils.PrintTaskInfo("task-1", "extract", time.Now(), []int64{1, 2, 3}, []string{"lod2_building"}, []string{"city2tabula"})
+
+		out := buf.String()
+		for _, want := range []string{"task-1", "extract", "lod2_building", "city2tabula", "[1 2 3]"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected output to contain %q, got:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("more than 5 building IDs are truncated", func(t *testing.T) {
+		buf := captureInfo(t)
+
+		utils.PrintTaskInfo("task-2", "extract", time.Now(), []int64{1, 2, 3, 4, 5, 6, 7}, nil, nil)
+
+		out := buf.String()
+		if !strings.Contains(out, "Building IDs:        [1 2 3 4 5]...") {
+			t.Errorf("expected building IDs truncated to the first 5 with a trailing ellipsis, got:\n%s", out)
+		}
+	})
+}
+
+func TestPrintJobInfo(t *testing.T) {
+	buf := captureInfo(t)
+
+	utils.PrintJobInfo("job-1", []int64{1, 2}, 4)
+
+	out := buf.String()
+	for _, want := range []string{"job-1", "Total Building IDs     : 2", "Total Tasks            : 4"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintJobQueueInfo(t *testing.T) {
+	buf := captureInfo(t)
+
+	utils.PrintJobQueueInfo(3, 8, &config.BatchConfig{Threads: 4})
+
+	out := buf.String()
+	for _, want := range []string{
+		"Total Jobs              : 3",
+		"Total Tasks per Job     : 8",
+		"Total Tasks             : 24", // 3 * 8
+		"Total Workers           : 4",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintWorkerInfo(t *testing.T) {
+	buf := captureInfo(t)
+
+	utils.PrintWorkerInfo(7)
+
+	if out := buf.String(); !strings.Contains(out, "Worker ID              : 7") {
+		t.Errorf("expected output to contain the worker ID, got:\n%s", out)
+	}
+}
+
+func TestPrintRunnerInfo(t *testing.T) {
+	buf := captureInfo(t)
+
+	utils.PrintRunnerInfo("task-1", "job-1", 5)
+
+	out := buf.String()
+	for _, want := range []string{"task-1", "job-1", "Total Tasks in Job:    5"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
`internal/utils` was at 7.6% coverage — only `CreateBatches` (`batch.go`) had tests. `exec.go`, `logger.go`, and `print.go` had none. Now at 96.2%.

- `isWindows` refactored to take `goos` as a parameter instead of reading `runtime.GOOS` directly, so its branching is testable on any platform (Linux CI included).
- `ExecuteCommand` covered via real `sh -c` invocations — success, non-zero exit, error message includes command output. No mocking needed, same approach already used for `psql`/`pg_dump` elsewhere in this repo.
- Logger: `setLogLevelFromEnv` (every `LOG_LEVEL` value plus unset/unknown), `getLogLevelName`, `SetLogLevel`, `IsDebugEnabled`, and `InitLogger`'s success path (fresh temp dir via `t.Chdir`, confirms the log file is created and the loggers stay usable afterward).
- All five `Print*Info` functions, including `PrintTaskInfo`'s >5-IDs truncation branch, verified by swapping `Info` for a buffer-backed logger and checking captured output.

**Deliberately left uncovered:** `ExecuteCommand`'s Windows-only `cmd.exe` branch (can't hit it on a Linux test runner without deeper mocking of `exec.Command` itself) and `InitLogger`'s `log.Fatalf` error paths (would exit the test process to exercise — same class of untestable `os.Exit` path already left alone in `importer.ImportCityDBData`).

## Test plan
- [x] `go test -v ./internal/utils/...` — all pass
- [x] `go build`/`go vet` (with and without `-tags integration`)
- [x] `go test -tags integration -timeout 15m ./internal/db/... ./internal/importer/... ./internal/process/...` — full suite still green (this package is a logging dependency of all three)