### PR TITLE
fix: run internal/db and internal/importer integration tests in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
         run: sudo apt-get install -y postgresql-client
 
       - name: Integration Tests
-        run: go test -tags integration -v -timeout 10m -coverprofile=coverage.out -covermode=atomic ./internal/process/
+        run: go test -tags integration -v -timeout 10m -coverprofile=coverage.out -covermode=atomic ./internal/process/ ./internal/db/ ./internal/importer/
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary
Root cause of the coverage percentage drop reported after #94 merged: the integration job's test command was still hardcoded to \`./internal/process/\` only. The testcontainers-based integration suites added for \`internal/db\` (38.1%) and \`internal/importer\` (27.8%) in #93 never actually ran in CI, so Codecov's \`integration\` flag never saw coverage data for either package — their combined report fell back to each package's much smaller unit-only numbers (just the handful of pure-logic tests like \`parseSRID\`). Merging #94 likely just triggered a report recompute that surfaced this for the first time; nothing in #94 itself caused a regression.

One-line fix: add the two missing package paths to the integration test command.

Verified locally by running all three packages under one \`-coverprofile\` (matching the fixed command exactly) — they merge correctly into a single profile, 60.7% combined across \`internal/process\`, \`internal/db\`, and \`internal/importer\`.

## Test plan
- [x] \`python3 -c "import yaml; yaml.safe_load(...)"\` — YAML valid
- [x] \`go test -tags integration -timeout 15m -coverprofile=... ./internal/process/ ./internal/db/ ./internal/importer/\` locally — all pass, coverage profile correctly includes all three packages