### PR TITLE
docs: update PyLovo2EnerPlanET references to enerplanet-pylovo

### DIFF
--- a/docs/code/pylovo-link/index.md
+++ b/docs/code/pylovo-link/index.md
@@ -1,6 +1,6 @@
 # PyLovo Building Link
 
-The PyLovo link step connects 3D building footprints extracted by City2TABULA to the OSM building data held in a [PyLovo2EnerPlanET](https://github.com/enerplanet/pylovo2enerplanet) database. The result is the `city2tabula.building_link` table, which records whether each 3D building has a matching OSM building, which PyLovo table it belongs to (`res` for residential, `oth` for commercial/public), and how confident the spatial match is.
+The PyLovo link step connects 3D building footprints extracted by City2TABULA to the OSM building data held in an [enerplanet-pylovo](https://github.com/enerplanet/enerplanet-pylovo) database. The result is the `city2tabula.building_link` table, which records whether each 3D building has a matching OSM building, which PyLovo table it belongs to (`res` for residential, `oth` for commercial/public), and how confident the spatial match is.
 
 This step is optional. Feature extraction (`-extract-features`) runs independently; linking enriches the output with OSM semantics and is needed only when connecting City2TABULA output to EnerPlanET.
 
@@ -105,4 +105,4 @@ sql/scripts/link/
 A future OGR2OGR-based OSM import would add a parallel subdirectory (`ogr2ogr/`) with its own script and a new `-link-ogr2ogr` flag — no changes to the existing pipeline.
 
 !!! info "Pre-requisite"
-    `pylovo.res` and `pylovo.oth` must be populated by the [pylovo2enerplanet/datapipeline](https://github.com/enerplanet/pylovo2enerplanet/tree/main/datapipeline) before running `-link-pylovo`. The link step reads from PyLovo but does not modify it.
+    `pylovo.res` and `pylovo.oth` must be populated by the [enerplanet-pylovo/datapipeline](https://github.com/enerplanet/enerplanet-pylovo/tree/main/datapipeline) before running `-link-pylovo`. The link step reads from PyLovo but does not modify it.

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -9,7 +9,7 @@ City2TABULA always produces the same core output — enriched building and surfa
 | **Steps run** | citydb-tool import → `-extract-features` | citydb-tool import → `-extract-features` → `-link-pylovo` |
 | **Final output** | `city2tabula.{lod}_building`, `city2tabula.{lod}_surface` | Standalone output, plus `city2tabula.building_link` |
 | **Who queries it** | Your own API, built against the schema directly | Application code joins through `building_link` |
-| **When to use it** | You only need City2TABULA's 3D building/surface data on its own terms | You need buildings that exist in *both* City2TABULA and a [PyLovo2EnerPlanET](https://github.com/enerplanet/pylovo2enerplanet) database — this is EnerPlanET's path |
+| **When to use it** | You only need City2TABULA's 3D building/surface data on its own terms | You need buildings that exist in *both* City2TABULA and an [enerplanet-pylovo](https://github.com/enerplanet/enerplanet-pylovo) database — this is EnerPlanET's path |
 
 ```mermaid
 flowchart TD
@@ -55,4 +55,4 @@ WHERE l.match_type = 1;
 Full detail on the matching algorithm, configuration (`PYLOVO_SCHEMA`, `PYLOVO_LINK_GRID_SIZE`), the `building_link` schema, and match types is in [PyLovo Building Link](../code/pylovo-link/index.md).
 
 !!! info "PyLovo must already have data"
-    `-link-pylovo` reads from `pylovo.res`/`pylovo.oth`; it doesn't populate them. Those tables must already be loaded via [pylovo2enerplanet/datapipeline](https://github.com/enerplanet/pylovo2enerplanet/tree/main/datapipeline) before this step will find any matches.
+    `-link-pylovo` reads from `pylovo.res`/`pylovo.oth`; it doesn't populate them. Those tables must already be loaded via [enerplanet-pylovo/datapipeline](https://github.com/enerplanet/enerplanet-pylovo/tree/main/datapipeline) before this step will find any matches.

--- a/internal/process/pylovo_link_build_test.go
+++ b/internal/process/pylovo_link_build_test.go
@@ -39,7 +39,7 @@ func pylovoLinkFixtureBuildings(t *testing.T, ctx context.Context) (a, b, c stri
 }
 
 // seedPylovoTestTables creates minimal pylovo.res / pylovo.oth tables (normally
-// owned by the external PyLovo2EnerPlanET database, not this repo) under the
+// owned by the external enerplanet-pylovo database, not this repo) under the
 // "public" schema, matching the columns 01_build_pylovo_link.sql reads: osm_id and
 // geom in EPSG:3035 (PyLovo's native CRS, per that script's own comments).
 func seedPylovoTestTables(t *testing.T, ctx context.Context) {


### PR DESCRIPTION
## Summary
PyLovo2EnerPlanET was renamed to [enerplanet-pylovo](https://github.com/enerplanet/enerplanet-pylovo). Updates the three places that named the old repo:
- `docs/deployment/index.md` (added in #95)
- `docs/code/pylovo-link/index.md`
- `internal/process/pylovo_link_build_test.go` (comment only, no behavior change)

The `datapipeline` subdirectory link target still exists at the same relative path in the renamed repo, so those links stay valid.

## Test plan
- [x] `mkdocs build --strict` — passes
- [x] `go build`/`go vet -tags integration ./...` — clean (comment-only Go change)