### PR TITLE
test: cover external-tool (psql/CityDB CLI) message and error handling

### DIFF
--- a/internal/db/citydb.go
+++ b/internal/db/citydb.go
@@ -24,6 +24,10 @@ func executeCityDBScript(cfg *config.Config, sqlFilePath, schemaName string) err
 		"-U", cfg.DB.User,
 		"-d", cfg.DB.Name,
 		"-p", cfg.DB.Port,
+		// Without this, psql prints a SQL error to stderr but still exits 0, so the
+		// already-exists/generic-failure branches below never fire - the script
+		// would silently "succeed" up to (and past) the first failing statement.
+		"-v", "ON_ERROR_STOP=1",
 		"-v", fmt.Sprintf("srid=%d", srid),
 		"-v", fmt.Sprintf("srs_name=%s", cfg.CityDB.SRSName),
 		"-f", sqlFilePath,

--- a/internal/db/citydb_integration_test.go
+++ b/internal/db/citydb_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thd-spatial-ai/city2tabula/internal/db"
+)
+
+// writeSQLScript writes a one-off SQL file for ExecuteCityDBScript to run, using
+// real psql against the shared testPool's database rather than mocking psql's
+// output - executeCityDBScript's branching (success / "already exists" / generic
+// failure) depends on what real psql actually prints, which is what's under test.
+func writeSQLScript(t *testing.T, sql string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "script.sql")
+	if err := os.WriteFile(path, []byte(sql), 0644); err != nil {
+		t.Fatalf("failed to write SQL script: %v", err)
+	}
+	return path
+}
+
+func TestExecuteCityDBScript_Success(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig("citytabula_dbtest")
+	const schema = "citydb_script_success_test"
+	defer testPool.Exec(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+
+	script := writeSQLScript(t, `CREATE SCHEMA `+schema+`;`)
+
+	if err := db.ExecuteCityDBScript(cfg, script, ""); err != nil {
+		t.Fatalf("ExecuteCityDBScript: %v", err)
+	}
+	if !schemaExists(t, ctx, schema) {
+		t.Errorf("expected schema %q to exist after a successful script run", schema)
+	}
+}
+
+// TestExecuteCityDBScript_AlreadyExistsIsDetected drives the branch that inspects
+// psql's real output for "already exists": running the same plain CREATE SCHEMA
+// (no IF NOT EXISTS) a second time makes Postgres itself raise that exact error,
+// rather than simulating the message.
+func TestExecuteCityDBScript_AlreadyExistsIsDetected(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig("citytabula_dbtest")
+	const schema = "citydb_script_exists_test"
+	defer testPool.Exec(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+
+	script := writeSQLScript(t, `CREATE SCHEMA `+schema+`;`)
+
+	if err := db.ExecuteCityDBScript(cfg, script, ""); err != nil {
+		t.Fatalf("first run (should succeed): %v", err)
+	}
+
+	err := db.ExecuteCityDBScript(cfg, script, "")
+	if err == nil {
+		t.Fatal("expected an error on the second run (schema already exists), got nil")
+	}
+	if !strings.Contains(err.Error(), "schema already exists") {
+		t.Errorf("expected the already-exists branch to be detected, got: %v", err)
+	}
+}
+
+// TestExecuteCityDBScript_GenericFailureIsNotMisreportedAsAlreadyExists exercises
+// the other side of that same branch: a script that fails for an unrelated reason
+// must not be mislabeled as "schema already exists".
+func TestExecuteCityDBScript_GenericFailureIsNotMisreportedAsAlreadyExists(t *testing.T) {
+	cfg := testConfig("citytabula_dbtest")
+	script := writeSQLScript(t, `THIS IS NOT VALID SQL;`)
+
+	err := db.ExecuteCityDBScript(cfg, script, "")
+	if err == nil {
+		t.Fatal("expected an error for invalid SQL, got nil")
+	}
+	if strings.Contains(err.Error(), "schema already exists") {
+		t.Errorf("expected a generic failure, got it misreported as already-exists: %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to execute CityDB script") {
+		t.Errorf("expected the generic-failure wrapper message, got: %v", err)
+	}
+}
+
+// TestExecuteCityDBScript_WithSchemaNameVariable confirms the schema_name psql
+// variable is only added to args when schemaName is non-empty (the WHERE
+// schemaName != "" branch in executeCityDBScript), using a script that
+// references :schema_name so a missing/wrong variable would fail the run.
+func TestExecuteCityDBScript_WithSchemaNameVariable(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig("citytabula_dbtest")
+	const schema = "citydb_script_var_test"
+	defer testPool.Exec(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+
+	script := writeSQLScript(t, `CREATE SCHEMA :schema_name;`)
+
+	if err := db.ExecuteCityDBScript(cfg, script, schema); err != nil {
+		t.Fatalf("ExecuteCityDBScript with schemaName: %v", err)
+	}
+	if !schemaExists(t, ctx, schema) {
+		t.Errorf("expected schema %q (from the schema_name psql variable) to exist", schema)
+	}
+}

--- a/internal/db/db_integration_test.go
+++ b/internal/db/db_integration_test.go
@@ -118,6 +118,10 @@ func testConfig(dbName string) *config.Config {
 				Lod3: "lod3",
 			},
 		},
+		CityDB: &config.CityDB{
+			SRID:    "25832",
+			SRSName: "urn:ogc:def:crs:EPSG::25832",
+		},
 		Batch: &config.BatchConfig{Threads: 2},
 	}
 }

--- a/internal/importer/citydb_test.go
+++ b/internal/importer/citydb_test.go
@@ -1,11 +1,31 @@
 package importer
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/thd-spatial-ai/city2tabula/internal/config"
 )
+
+// writeFakeExecutable writes an executable shell script named "citydb" to dir that
+// appends its arguments to logPath (one line per invocation) and exits with
+// exitCode. Standing in for the real CityDB Java CLI tool, which isn't available
+// in the test environment - real process, fake binary, so testCityDBExecPath /
+// executeCityDBCommand / importCityDBFiles / ImportCityDBData can be exercised
+// without mocking exec.Command itself.
+func writeFakeExecutable(t *testing.T, dir string, exitCode int, logPath string) string {
+	t.Helper()
+	scriptPath := filepath.Join(dir, "citydb")
+	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\nexit %d\n", logPath, exitCode)
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to write fake citydb executable: %v", err)
+	}
+	return scriptPath
+}
 
 func minimalCityDBConfig() *config.Config {
 	return &config.Config{
@@ -113,5 +133,123 @@ func TestImportCityDBFiles_MissingPathReturnsNil(t *testing.T) {
 	// Then: missing path is treated as optional — skip with no error
 	if err != nil {
 		t.Errorf("expected nil error for missing data path, got %v", err)
+	}
+}
+
+func TestTestCityDBExecPath_Success(t *testing.T) {
+	dir := t.TempDir()
+	exe := writeFakeExecutable(t, dir, 0, filepath.Join(dir, "log.txt"))
+
+	if err := testCityDBExecPath(exe); err != nil {
+		t.Errorf("expected nil error when -help succeeds, got %v", err)
+	}
+}
+
+func TestTestCityDBExecPath_Failure(t *testing.T) {
+	dir := t.TempDir()
+	exe := writeFakeExecutable(t, dir, 1, filepath.Join(dir, "log.txt"))
+
+	if err := testCityDBExecPath(exe); err == nil {
+		t.Error("expected an error when -help fails, got nil")
+	}
+}
+
+func TestExecuteCityDBCommand_Success(t *testing.T) {
+	dir := t.TempDir()
+	exe := writeFakeExecutable(t, dir, 0, filepath.Join(dir, "log.txt"))
+	cmd := exec.Command(exe, "import")
+
+	if err := executeCityDBCommand(cmd, "test import"); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}
+
+func TestExecuteCityDBCommand_Failure(t *testing.T) {
+	dir := t.TempDir()
+	exe := writeFakeExecutable(t, dir, 1, filepath.Join(dir, "log.txt"))
+	cmd := exec.Command(exe, "import")
+
+	if err := executeCityDBCommand(cmd, "test import"); err == nil {
+		t.Error("expected an error when the command exits non-zero, got nil")
+	}
+}
+
+func TestImportCityDBFiles_BothFormatsAttemptedOnSuccess(t *testing.T) {
+	dataDir := t.TempDir() // exists -> passes the os.Stat check
+	exeDir := t.TempDir()
+	logPath := filepath.Join(exeDir, "invocations.log")
+	exe := writeFakeExecutable(t, exeDir, 0, logPath)
+	cfg := minimalCityDBConfig()
+
+	if err := importCityDBFiles(exe, dataDir, "lod2", "LOD2", cfg); err != nil {
+		t.Fatalf("importCityDBFiles: %v", err)
+	}
+
+	logContent, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read invocation log: %v", err)
+	}
+	for _, want := range []string{"citygml", "cityjson"} {
+		if !strings.Contains(string(logContent), want) {
+			t.Errorf("expected %q to have been invoked, log:\n%s", want, logContent)
+		}
+	}
+}
+
+// TestImportCityDBFiles_CityGMLFailureShortCircuitsCityJSON guards the early
+// return in importCityDBFiles's format loop: if the CityGML import fails,
+// CityJSON must never be attempted for that LOD level.
+func TestImportCityDBFiles_CityGMLFailureShortCircuitsCityJSON(t *testing.T) {
+	dataDir := t.TempDir()
+	exeDir := t.TempDir()
+	logPath := filepath.Join(exeDir, "invocations.log")
+	exe := writeFakeExecutable(t, exeDir, 1, logPath) // always fails
+	cfg := minimalCityDBConfig()
+
+	if err := importCityDBFiles(exe, dataDir, "lod2", "LOD2", cfg); err == nil {
+		t.Fatal("expected an error when the citygml import fails, got nil")
+	}
+
+	logContent, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read invocation log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(logContent)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 invocation (citygml only, cityjson short-circuited), got %d:\n%s", len(lines), logContent)
+	}
+	if !strings.Contains(lines[0], "citygml") {
+		t.Errorf("expected the one invocation to be citygml, got: %s", lines[0])
+	}
+}
+
+// TestImportCityDBData_Success drives ImportCityDBData end to end (exec-path
+// check, -help test, LOD2 + LOD3 imports) against a fake executable. The one
+// branch deliberately left untouched is the missing-exec-path case, which calls
+// utils.Error.Fatalf (os.Exit) and can't be exercised without killing the test
+// process.
+func TestImportCityDBData_Success(t *testing.T) {
+	exeDir := t.TempDir()
+	logPath := filepath.Join(exeDir, "invocations.log")
+	writeFakeExecutable(t, exeDir, 0, logPath) // must be named "citydb" inside exeDir
+
+	lod2Dir, lod3Dir := t.TempDir(), t.TempDir()
+	cfg := minimalCityDBConfig()
+	cfg.CityDB.ToolPath = exeDir
+	cfg.Data = &config.DataPaths{Lod2: lod2Dir, Lod3: lod3Dir}
+	cfg.DB.Schemas = &config.Schemas{Lod2: "lod2", Lod3: "lod3"}
+
+	if err := ImportCityDBData(nil, cfg); err != nil {
+		t.Fatalf("ImportCityDBData: %v", err)
+	}
+
+	logContent, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read invocation log: %v", err)
+	}
+	// -help, then citygml+cityjson for each of LOD2 and LOD3 = 5 invocations.
+	lines := strings.Split(strings.TrimSpace(string(logContent)), "\n")
+	if len(lines) != 5 {
+		t.Errorf("expected 5 invocations (-help + 2 formats x 2 LOD levels), got %d:\n%s", len(lines), logContent)
 	}
 }


### PR DESCRIPTION
## Summary
Both files that branch on what an external tool (psql, the CityDB Java CLI) prints or how it exits had zero coverage for that logic. One real bug found and fixed along the way.

**Bug found and fixed:** \`executeCityDBScript\` (\`internal/db/citydb.go\`) was missing \`-v ON_ERROR_STOP=1\` on its \`psql\` invocation. Without it, \`psql -f script.sql\` prints a SQL error to stderr but still **exits 0** — so the function's own already-exists/generic-failure branches (\`strings.Contains(output, "already exists")\`) could never actually fire for a typical SQL-level failure like \`CREATE SCHEMA\` on a schema that already exists. A partially-failing CityDB creation script would silently report success. \`internal/process/integration_test.go\`'s \`seedDB\` already uses this same flag for the same reason — this file was just missed.

**New coverage:**
- \`executeCityDBScript\`: 0% → 94.1%. Tested against **real \`psql\`** (not mocked output) — a plain \`CREATE SCHEMA\` run twice genuinely makes Postgres raise "already exists", proving the detection branch actually works now, plus a generic-SQL-failure case confirming it isn't misreported as already-exists.
- \`testCityDBExecPath\`, \`executeCityDBCommand\`, \`importCityDBFiles\`: 0%/30% → 100%. \`ImportCityDBData\`: 0% → 54.5%. These shell out to the real CityDB Java CLI tool, unavailable in the test environment — rather than mocking \`exec.Command\`, they're driven by a tiny fake shell script standing in for the real binary (real process, fake tool), with a controllable exit code and an args log for asserting what was actually invoked. Covers success/failure for each, plus \`importCityDBFiles\`'s format-loop short-circuit (a CityGML failure must stop before CityJSON is ever attempted).

**Deliberately left untouched:** \`ImportCityDBData\`'s missing-exec-path branch, which calls \`utils.Error.Fatalf\` (\`os.Exit\`) and can't be exercised without killing the test process.

\`internal/db\`: 38.1% → 47.1%. \`internal/importer\`: 27.8% → 62.5%.

## Test plan
- [x] \`go test -tags integration -timeout 15m ./internal/db/... ./internal/importer/... ./internal/process/...\` — full suite green, no regressions
- [x] \`go build\`/\`go vet\` (with and without \`-tags integration\`)