### PR TITLE
chore: wait for both coverage uploads before posting a Codecov status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+# go.yml uploads coverage twice per commit: the "unit" job runs go test ./...
+# (no build tag) and the "integration" job runs go test -tags integration on the
+# DB-dependent packages. Without this, Codecov posts a status as soon as either
+# upload lands - since the unit job usually finishes first and barely touches
+# DB-dependent code, PRs would briefly show a failing patch-coverage check that
+# flips to passing once the integration job's upload arrives a bit later.
+# after_n_builds waits for both before posting a final status.
+codecov:
+  notify:
+    after_n_builds: 2


### PR DESCRIPTION
## Summary
Observed on #98: PRs briefly show a failing \`codecov/patch\` check that flips to passing a couple minutes later. Root cause: \`go.yml\` uploads coverage twice per commit under separate flags (\`unit\`, \`integration\`), and without \`after_n_builds\` configured, Codecov posts a status as soon as *either* upload lands. The \`unit\` job finishes first and barely touches DB-dependent code (most of \`internal/db\`/\`internal/importer\`/\`internal/process\` is only exercised by \`-tags integration\` tests), so its partial view of the diff often reads as a coverage drop until the \`integration\` job's upload arrives and the combined report is complete.

Adds a minimal \`codecov.yml\` with \`notify.after_n_builds: 2\` so Codecov waits for both uploads before posting a final status — no more transient false-fail.

## Test plan
- [x] \`python3 -c "import yaml; yaml.safe_load(...)"\` — valid YAML, correct \`codecov:\` structure
- [x] Confirm on this PR's own CI run that only one (correct, final) \`codecov/patch\` status appears instead of a fail-then-pass flap