### PR TITLE
test: cover InitLogger's DEBUG-level stdout routing branch

### DIFF
--- a/internal/utils/logger_test.go
+++ b/internal/utils/logger_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,5 +136,36 @@ func TestInitLogger_CreatesLogFileAndWritesToIt(t *testing.T) {
 	Info.Printf("marker line")
 	if !strings.Contains(buf.String(), "marker line") {
 		t.Error("expected Info logger to still be usable after InitLogger")
+	}
+}
+
+// TestInitLogger_DebugLevelRoutesDebugOutputToStdout covers the other side of
+// InitLogger's currentLogLevel <= LogLevelDebug branch: with LOG_LEVEL=DEBUG,
+// multiDebug must be io.MultiWriter(os.Stdout, logFile), not just the log file.
+// Proven by actually redirecting os.Stdout to a pipe and reading what Debug
+// writes to it - not just executing the line, but checking its real effect.
+func TestInitLogger_DebugLevelRoutesDebugOutputToStdout(t *testing.T) {
+	restoreLoggerState(t)
+	t.Chdir(t.TempDir())
+	t.Setenv("LOG_LEVEL", "DEBUG")
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	InitLogger()
+	Debug.Printf("debug-marker")
+	w.Close()
+
+	captured, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read captured stdout: %v", err)
+	}
+	if !strings.Contains(string(captured), "debug-marker") {
+		t.Errorf("expected DEBUG-level InitLogger to route Debug output to stdout too, got: %q", captured)
 	}
 }


### PR DESCRIPTION
## Summary
\`internal/utils\` was at 96.2%, and the Codecov file view showed \`logger.go\` at 87.27% with a "Partial" line at InitLogger's \`if currentLogLevel <= LogLevelDebug\` check. The existing \`InitLogger\` test only ran with \`LOG_LEVEL\` unset (INFO default), so it only ever exercised the \`else\` branch (Debug output goes to the log file only) — never the \`if\` branch (Debug output also goes to stdout).

Adds a test that sets \`LOG_LEVEL=DEBUG\`, redirects \`os.Stdout\` to a real pipe, and confirms \`Debug.Printf\` output actually lands there — proving the branch's real behavior, not just executing the line.

\`internal/utils\`: 96.2% → 97.1%. The remaining gaps are unchanged from #94: \`ExecuteCommand\`'s Windows-only \`cmd.exe\` branch (can't hit it on a Linux test runner) and \`InitLogger\`'s two \`log.Fatalf\`/\`os.Exit\` paths (would kill the test process to exercise).

## Test plan
- [x] \`go test -v -run TestInitLogger ./internal/utils/...\` — both cases pass
- [x] \`go test ./...\` and \`go build -tags integration ./...\` — no regressions