### PR TITLE
test: cover internal/process's remaining low-coverage files (83.3% -> 94.3%)

### DIFF
--- a/internal/process/feature_extraction_test.go
+++ b/internal/process/feature_extraction_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/thd-spatial-ai/city2tabula/internal/config"
@@ -180,5 +181,26 @@ func TestLodSchema(t *testing.T) {
 				t.Errorf("lodSchema(%d) = %q, want %q", tc.lod, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestRunFeatureExtraction_UnsupportedLODReturnsErrorWithoutTouchingDB covers
+// RunFeatureExtraction's own propagation of lodSchema's error: an unsupported
+// LOD level in cfg.CityDB.LODLevels must fail on the very first iteration,
+// before pool is ever dereferenced - safe to pass nil for it here.
+func TestRunFeatureExtraction_UnsupportedLODReturnsErrorWithoutTouchingDB(t *testing.T) {
+	cfg := &config.Config{
+		DB: &config.DBConfig{
+			Schemas: &config.Schemas{Lod2: "lod2", Lod3: "lod3"},
+		},
+		CityDB: &config.CityDB{LODLevels: []int{99}},
+	}
+
+	err := RunFeatureExtraction(cfg, nil)
+	if err == nil {
+		t.Fatal("expected an error for an unsupported LOD level, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported LOD level") {
+		t.Errorf("expected the lodSchema error to propagate unchanged, got: %v", err)
 	}
 }

--- a/internal/process/orchestrator_test.go
+++ b/internal/process/orchestrator_test.go
@@ -1,0 +1,146 @@
+package process
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/thd-spatial-ai/city2tabula/internal/config"
+)
+
+// TestCreateJob_AllJobTypes covers every JobType branch in createJob's switch,
+// including MainTable and PyLovoLink, which no production caller currently
+// passes (MainDBSetupJobQueue uses LOD2/LOD3 for main-table scripts despite
+// the MainTable constant existing) - createJob itself is pure and
+// dependency-free, so every case is directly testable without a DB.
+func TestCreateJob_AllJobTypes(t *testing.T) {
+	cases := []struct {
+		jobType      JobType
+		wantPrefix   string
+		wantLodLevel int
+	}{
+		{LOD2, "LOD2", 2},
+		{LOD3, "LOD3", 3},
+		{Function, "FUNCTION", -1},
+		{MainTable, "MAIN_TABLE", -1},
+		{Supplementary, "SUPPLEMENTARY", -1},
+		{SupplementaryTable, "SUPPLEMENTARY_TABLE", -1},
+		{PyLovoLink, "PYLOVO_LINK", 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.jobType), func(t *testing.T) {
+			batch := []int64{1, 2}
+			scripts := []string{"sql/scripts/main/01_create_link_tables.sql", "sql/scripts/main/02_create_link_tables.sql"}
+
+			job := createJob(batch, scripts, tc.jobType)
+
+			if len(job.Tasks) != len(scripts) {
+				t.Fatalf("expected %d tasks (one per script), got %d", len(scripts), len(job.Tasks))
+			}
+			for i, task := range job.Tasks {
+				if !strings.HasPrefix(task.TaskType, tc.wantPrefix+":") {
+					t.Errorf("task %d: expected TaskType to start with %q, got %q", i, tc.wantPrefix+":", task.TaskType)
+				}
+				if task.LodLevel != tc.wantLodLevel {
+					t.Errorf("task %d: LodLevel = %d, want %d", i, task.LodLevel, tc.wantLodLevel)
+				}
+				if task.Priority != i+1 {
+					t.Errorf("task %d: Priority = %d, want %d", i, task.Priority, i+1)
+				}
+			}
+		})
+	}
+}
+
+// TestCreateJob_UnknownJobTypeGetsNoPrefix documents the switch's implicit
+// default: a JobType with no matching case leaves prefix empty rather than
+// erroring - createJob has no fallback/validation for this today.
+func TestCreateJob_UnknownJobTypeGetsNoPrefix(t *testing.T) {
+	job := createJob([]int64{1}, []string{"script.sql"}, JobType("unknown"))
+
+	if len(job.Tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(job.Tasks))
+	}
+	if !strings.HasPrefix(job.Tasks[0].TaskType, ": ") {
+		t.Errorf("expected an empty prefix for an unrecognised JobType, got TaskType %q", job.Tasks[0].TaskType)
+	}
+}
+
+// TestBuildFeatureExtractionQueue_BothLODsProduceJobs covers the LOD3 batch
+// loop, which no existing test exercises (every fixture only seeds LOD2 data)
+// - BuildFeatureExtractionQueue itself only loads script paths from disk and
+// builds Job/Task structs, so no DB is needed to exercise it with non-empty
+// LOD3 batches.
+func TestBuildFeatureExtractionQueue_BothLODsProduceJobs(t *testing.T) {
+	if err := os.Chdir(projectRoot()); err != nil {
+		t.Fatalf("chdir to project root: %v", err)
+	}
+	cfg := &config.Config{}
+
+	queue, err := BuildFeatureExtractionQueue(cfg, [][]int64{{1, 2}}, [][]int64{{3, 4}})
+	if err != nil {
+		t.Fatalf("BuildFeatureExtractionQueue: %v", err)
+	}
+	if queue.Len() != 2 {
+		t.Fatalf("expected 1 job per LOD (2 total), got %d", queue.Len())
+	}
+}
+
+// TestJobQueueBuilders_LoadSQLScriptsFailurePropagates drives every queue
+// builder's error-wrap for a failed config.LoadSQLScripts() call by chdir-ing
+// somewhere with no sql/ directory tree - one root cause covering five
+// separate call sites (BuildFeatureExtractionQueue calls LoadSQLScripts
+// directly; the other four go through the shared loadScriptsAndQueue helper).
+func TestJobQueueBuilders_LoadSQLScriptsFailurePropagates(t *testing.T) {
+	t.Chdir(t.TempDir())
+	cfg := &config.Config{}
+
+	builders := map[string]func() error{
+		"BuildFeatureExtractionQueue": func() error {
+			_, err := BuildFeatureExtractionQueue(cfg, nil, nil)
+			return err
+		},
+		"MainDBSetupJobQueue": func() error {
+			_, err := MainDBSetupJobQueue(cfg)
+			return err
+		},
+		"SupplementaryDBSetupJobQueue": func() error {
+			_, err := SupplementaryDBSetupJobQueue(cfg)
+			return err
+		},
+		"SupplementaryJobQueue": func() error {
+			_, err := SupplementaryJobQueue(cfg)
+			return err
+		},
+		"PyLovoLinkJobQueue": func() error {
+			_, err := PyLovoLinkJobQueue(cfg, nil)
+			return err
+		},
+	}
+
+	for name, call := range builders {
+		t.Run(name, func(t *testing.T) {
+			if err := call(); err == nil {
+				t.Errorf("expected %s to propagate a LoadSQLScripts failure, got nil", name)
+			}
+		})
+	}
+}
+
+// TestSupplementaryJobQueue_Success covers SupplementaryJobQueue's happy
+// path, which no other test calls at all.
+func TestSupplementaryJobQueue_Success(t *testing.T) {
+	if err := os.Chdir(projectRoot()); err != nil {
+		t.Fatalf("chdir to project root: %v", err)
+	}
+	cfg := &config.Config{}
+
+	queue, err := SupplementaryJobQueue(cfg)
+	if err != nil {
+		t.Fatalf("SupplementaryJobQueue: %v", err)
+	}
+	if queue.Len() == 0 {
+		t.Error("expected at least 1 job from the supplementary scripts directory")
+	}
+}

--- a/internal/process/query_sql_worker_integration_test.go
+++ b/internal/process/query_sql_worker_integration_test.go
@@ -1,0 +1,209 @@
+//go:build integration
+
+package process_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/thd-spatial-ai/city2tabula/internal/config"
+	"github.com/thd-spatial-ai/city2tabula/internal/process"
+)
+
+// TestRunFeatureExtraction_BadLod2SchemaPropagatesQueryError drives
+// getBuildingObjectClassIDs's real query-error branch (query.go) through
+// RunFeatureExtraction's own error-wrap: a schema name that doesn't exist at
+// all produces a genuine Postgres "relation does not exist" error, not a
+// simulated one.
+func TestRunFeatureExtraction_BadLod2SchemaPropagatesQueryError(t *testing.T) {
+	tc := setupGermanyLOD2(t)
+
+	cfg := pipelineConfig(*tc)
+	cfg.DB.Schemas.Lod2 = "schema_that_does_not_exist"
+
+	err := process.RunFeatureExtraction(cfg, testPool)
+	if err == nil {
+		t.Fatal("expected an error for a nonexistent LOD2 schema, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to get LOD2 building IDs") {
+		t.Errorf("expected RunFeatureExtraction's own error wrap, got: %v", err)
+	}
+}
+
+// TestRunFeatureExtraction_MissingCity2TabulaSchemaPropagatesProcessedIDsError
+// drives getProcessedBuildingFeatureIDs's real query-error branch: real LOD2
+// CityDB data exists (so getBuildingIDsFromCityDB succeeds), but the
+// city2tabula schema hasn't been set up yet, so the already-processed check
+// fails for real.
+func TestRunFeatureExtraction_MissingCity2TabulaSchemaPropagatesProcessedIDsError(t *testing.T) {
+	tc := setupGermanyLOD2(t)
+	ctx := context.Background()
+
+	// setupGermanyLOD2 already ran db.RunCity2TabulaDBSetup, so drop it back off
+	// to reproduce "CityDB data exists, city2tabula schema does not".
+	if _, err := testPool.Exec(ctx, `DROP SCHEMA IF EXISTS city2tabula CASCADE`); err != nil {
+		t.Fatalf("failed to drop city2tabula schema: %v", err)
+	}
+
+	cfg := pipelineConfig(*tc)
+	err := process.RunFeatureExtraction(cfg, testPool)
+	if err == nil {
+		t.Fatal("expected an error when city2tabula schema is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to filter already-processed LOD2 building IDs") {
+		t.Errorf("expected RunFeatureExtraction's own error wrap, got: %v", err)
+	}
+}
+
+// TestRunTaskWithRetry_ExecuteSQLScriptFailureIsWrapped drives runSingleTask's
+// executeSQLScript-failure branch (runner.go) and executeSQLScript's own
+// conn.Exec error branch (sql.go) together: a real SQL file with invalid SQL,
+// run against the real testPool. MaxRetries: 0 keeps it to a single attempt.
+func TestRunTaskWithRetry_ExecuteSQLScriptFailureIsWrapped(t *testing.T) {
+	cfg := pipelineConfig(pipelineTestCase{country: "germany", srid: "25832"})
+	cfg.RetryConfig = &config.RetryConfig{MaxRetries: 0, DeadlockRetries: 0}
+
+	scriptPath := filepath.Join(t.TempDir(), "bad.sql")
+	if err := os.WriteFile(scriptPath, []byte("THIS IS NOT VALID SQL;"), 0644); err != nil {
+		t.Fatalf("failed to write SQL fixture: %v", err)
+	}
+
+	runner := process.NewRunner(cfg)
+	task := process.NewTask("TEST: bad script", process.Params{}, scriptPath, 1, -1)
+
+	err := runner.RunTaskWithRetry(task, testPool, cfg, 1)
+	if err == nil {
+		t.Fatal("expected an error for invalid SQL, got nil")
+	}
+	if !strings.Contains(err.Error(), scriptPath) {
+		t.Errorf("expected the error to name the failing SQL file, got: %v", err)
+	}
+}
+
+// TestWorkerStart_ContinuesPastFailedJob covers Worker.Start's error-continue
+// branch: the first job's task fails for real (invalid SQL), the second job's
+// task is real valid SQL that leaves a detectable side effect - proving Start
+// drains the whole channel instead of exiting after the first failure.
+func TestWorkerStart_ContinuesPastFailedJob(t *testing.T) {
+	ctx := context.Background()
+	cfg := pipelineConfig(pipelineTestCase{country: "germany", srid: "25832"})
+	cfg.RetryConfig = &config.RetryConfig{MaxRetries: 0, DeadlockRetries: 0}
+
+	const markerTable = "worker_continue_marker_test"
+	if _, err := testPool.Exec(ctx, `DROP TABLE IF EXISTS `+markerTable); err != nil {
+		t.Fatalf("failed to clean up marker table: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DROP TABLE IF EXISTS `+markerTable) })
+
+	badScript := filepath.Join(t.TempDir(), "bad.sql")
+	if err := os.WriteFile(badScript, []byte("THIS IS NOT VALID SQL;"), 0644); err != nil {
+		t.Fatalf("failed to write bad SQL fixture: %v", err)
+	}
+	goodScript := filepath.Join(t.TempDir(), "good.sql")
+	if err := os.WriteFile(goodScript, []byte(`CREATE TABLE `+markerTable+` (id int);`), 0644); err != nil {
+		t.Fatalf("failed to write good SQL fixture: %v", err)
+	}
+
+	failingJob := process.NewJob([]int64{1}, []*process.Task{
+		process.NewTask("TEST: failing", process.Params{}, badScript, 1, -1),
+	})
+	succeedingJob := process.NewJob([]int64{2}, []*process.Task{
+		process.NewTask("TEST: succeeding", process.Params{}, goodScript, 1, -1),
+	})
+
+	queue := process.NewJobQueue()
+	queue.Enqueue(failingJob)
+	queue.Enqueue(succeedingJob)
+	jobChan := queue.ToChannel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	worker := process.NewWorker(1)
+	worker.Start(jobChan, testPool, &wg, cfg)
+	wg.Wait() // Start itself calls wg.Done() via defer; Wait just confirms it returned.
+
+	var exists bool
+	if err := testPool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = $1)`, markerTable,
+	).Scan(&exists); err != nil {
+		t.Fatalf("failed to check marker table: %v", err)
+	}
+	if !exists {
+		t.Error("expected the second job's task to have run despite the first job's failure — Start likely exited early instead of continuing")
+	}
+}
+
+// TestGetBuildingObjectClassIDs_ScanErrorPropagates drives query.go's
+// getBuildingObjectClassIDs rows.Scan error branch - not simulated: a NUMERIC
+// column holding a fractional value (950.5) makes the query itself succeed
+// (950.5 legitimately satisfies "BETWEEN 900 AND 999") while pgx's scan into
+// a plain int genuinely fails, since a fractional value can't be losslessly
+// converted.
+func TestGetBuildingObjectClassIDs_ScanErrorPropagates(t *testing.T) {
+	ctx := context.Background()
+	const schema = "scan_error_objectclass_test"
+	mustExec(t, ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+	t.Cleanup(func() { testPool.Exec(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`) })
+	mustExec(t, ctx, `CREATE SCHEMA `+schema)
+	mustExec(t, ctx, `CREATE TABLE `+schema+`.feature (objectclass_id NUMERIC)`)
+	mustExec(t, ctx, `INSERT INTO `+schema+`.feature (objectclass_id) VALUES (950.5)`)
+
+	cfg := pipelineConfig(pipelineTestCase{country: "germany", srid: "25832"})
+	cfg.DB.Schemas.Lod2 = schema
+
+	err := process.RunFeatureExtraction(cfg, testPool)
+	if err == nil {
+		t.Fatal("expected a scan error to propagate, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to get LOD2 building IDs") {
+		t.Errorf("expected RunFeatureExtraction's error wrap, got: %v", err)
+	}
+}
+
+// TestGetProcessedBuildingFeatureIDs_ScanErrorPropagates drives query.go's
+// getProcessedBuildingFeatureIDs rows.Scan error branch, reached from
+// RunFeatureExtraction only after getBuildingIDsFromCityDB has already
+// succeeded - so this needs real LOD2 CityDB data, plus a city2tabula
+// _building table whose building_feature_id is a fractional NUMERIC.
+//
+// The already-processed check only queries rows that already exist, so a
+// first, clean RunFeatureExtraction run is needed to populate
+// city2tabula.lod2_building before corrupting a row and running again.
+func TestGetProcessedBuildingFeatureIDs_ScanErrorPropagates(t *testing.T) {
+	tc := setupGermanyLOD2(t)
+	ctx := context.Background()
+	cfg := pipelineConfig(*tc)
+
+	if err := process.RunFeatureExtraction(cfg, testPool); err != nil {
+		t.Fatalf("initial RunFeatureExtraction (populates fixture data): %v", err)
+	}
+
+	mustExec(t, ctx, `ALTER TABLE city2tabula.lod2_building ALTER COLUMN building_feature_id TYPE NUMERIC`)
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `ALTER TABLE city2tabula.lod2_building ALTER COLUMN building_feature_id TYPE INTEGER USING building_feature_id::INTEGER`)
+	})
+	// Only one row gets a fractional value - building_feature_id is UNIQUE, so
+	// setting every row to the same 1.5 would fail the UPDATE itself before
+	// scanning ever comes into play.
+	mustExec(t, ctx, `UPDATE city2tabula.lod2_building SET building_feature_id = 1.5
+		WHERE building_feature_id = (SELECT building_feature_id FROM city2tabula.lod2_building WHERE building_feature_id IS NOT NULL LIMIT 1)`)
+
+	err := process.RunFeatureExtraction(cfg, testPool)
+	if err == nil {
+		t.Fatal("expected a scan error to propagate, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to filter already-processed LOD2 building IDs") {
+		t.Errorf("expected RunFeatureExtraction's error wrap, got: %v", err)
+	}
+}
+
+func mustExec(t *testing.T, ctx context.Context, sql string) {
+	t.Helper()
+	if _, err := testPool.Exec(ctx, sql); err != nil {
+		t.Fatalf("setup query failed (%s): %v", sql, err)
+	}
+}

--- a/internal/process/runner.go
+++ b/internal/process/runner.go
@@ -16,13 +16,19 @@ import (
 // Runner handles execution of tasks and jobs
 type Runner struct {
 	config *config.Config
+
+	// runTask defaults to r.runSingleTask; tests override it to inject canned
+	// errors (deadlock, generic, success-after-N) so RunTaskWithRetry's retry/
+	// backoff/exhaustion branches are testable fast, without needing a real
+	// Postgres deadlock or waiting through real retry delays.
+	runTask func(task *Task, conn *pgxpool.Pool, workerID int) error
 }
 
 // NewRunner creates a new runner instance
 func NewRunner(config *config.Config) *Runner {
-	return &Runner{
-		config: config,
-	}
+	r := &Runner{config: config}
+	r.runTask = r.runSingleTask
+	return r
 }
 
 // RunJob executes all tasks in a job in priority order
@@ -49,7 +55,7 @@ func (r *Runner) RunTaskWithRetry(task *Task, conn *pgxpool.Pool, config *config
 	maxRetries := retryConfig.MaxRetries
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		err := r.runSingleTask(task, conn, workerID)
+		err := r.runTask(task, conn, workerID)
 
 		if err == nil {
 			if attempt > 0 {

--- a/internal/process/runner_test.go
+++ b/internal/process/runner_test.go
@@ -2,7 +2,13 @@ package process
 
 import (
 	"errors"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/thd-spatial-ai/city2tabula/internal/config"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // TestIsDeadLockError verifies that isDeadlockError correctly identifies PostgreSQL deadlock errors.
@@ -50,5 +56,183 @@ func TestIsDeadLockError(t *testing.T) {
 				t.Errorf("isDeadlockError(%v) = %v; want %v", tc.err, got, tc.want)
 			}
 		})
+	}
+}
+
+// fastRetryConfig keeps every delay at 1ms so the retry-exhaustion tests below
+// don't actually wait through real backoff sleeps.
+func fastRetryConfig() *config.RetryConfig {
+	return &config.RetryConfig{
+		MaxRetries:      3,
+		RetryDelay:      time.Millisecond,
+		DeadlockRetries: 2,
+		DeadlockDelay:   time.Millisecond,
+	}
+}
+
+func newTestRunnerAndTask(retryConfig *config.RetryConfig) (*Runner, *Task) {
+	cfg := &config.Config{RetryConfig: retryConfig}
+	r := NewRunner(cfg)
+	task := NewTask("TEST: task", Params{}, "irrelevant.sql", 1, -1)
+	return r, task
+}
+
+// TestRunTaskWithRetry_SucceedsFirstTry covers the zero-retry happy path: one
+// call to runTask, nil error, no retry logging.
+func TestRunTaskWithRetry_SucceedsFirstTry(t *testing.T) {
+	r, task := newTestRunnerAndTask(fastRetryConfig())
+	calls := 0
+	r.runTask = func(task *Task, conn *pgxpool.Pool, workerID int) error {
+		calls++
+		return nil
+	}
+
+	if err := r.RunTaskWithRetry(task, nil, r.config, 1); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 call on first-try success, got %d", calls)
+	}
+}
+
+// TestRunTaskWithRetry_SucceedsAfterGenericRetries drives the "attempt > 0"
+// success-logging branch and the regular (non-deadlock) retry-and-sleep branch:
+// two generic failures, then success on the third attempt.
+func TestRunTaskWithRetry_SucceedsAfterGenericRetries(t *testing.T) {
+	r, task := newTestRunnerAndTask(fastRetryConfig())
+	calls := 0
+	r.runTask = func(task *Task, conn *pgxpool.Pool, workerID int) error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient failure")
+		}
+		return nil
+	}
+
+	if err := r.RunTaskWithRetry(task, nil, r.config, 1); err != nil {
+		t.Fatalf("expected nil error after eventual success, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls (2 failures + 1 success), got %d", calls)
+	}
+}
+
+// TestRunTaskWithRetry_GenericRetriesExhausted drives the exhaustion branch:
+// runTask always fails with a non-deadlock error, so the loop runs
+// MaxRetries+1 times and returns a wrapped "failed after N retries" error.
+func TestRunTaskWithRetry_GenericRetriesExhausted(t *testing.T) {
+	retryConfig := fastRetryConfig()
+	r, task := newTestRunnerAndTask(retryConfig)
+	calls := 0
+	wantErr := errors.New("persistent failure")
+	r.runTask = func(task *Task, conn *pgxpool.Pool, workerID int) error {
+		calls++
+		return wantErr
+	}
+
+	err := r.RunTaskWithRetry(task, nil, r.config, 1)
+	if err == nil {
+		t.Fatal("expected an error after retries are exhausted, got nil")
+	}
+	if calls != retryConfig.MaxRetries+1 {
+		t.Errorf("expected %d calls (MaxRetries+1), got %d", retryConfig.MaxRetries+1, calls)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected the final error to wrap the last underlying error, got: %v", err)
+	}
+}
+
+// TestRunTaskWithRetry_DeadlockSucceedsAfterRetries drives the
+// deadlock-detected-then-retry branch: two deadlock errors, then success.
+func TestRunTaskWithRetry_DeadlockSucceedsAfterRetries(t *testing.T) {
+	r, task := newTestRunnerAndTask(fastRetryConfig())
+	calls := 0
+	r.runTask = func(task *Task, conn *pgxpool.Pool, workerID int) error {
+		calls++
+		if calls < 3 {
+			return errors.New("ERROR: deadlock detected")
+		}
+		return nil
+	}
+
+	if err := r.RunTaskWithRetry(task, nil, r.config, 1); err != nil {
+		t.Fatalf("expected nil error after eventual success, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls (2 deadlocks + 1 success), got %d", calls)
+	}
+}
+
+// TestRunTaskWithRetry_DeadlockRetriesExhausted drives the deadlock-specific
+// exhaustion branch, which returns after DeadlockRetries+1 attempts - a
+// separate limit from MaxRetries, and must not fall through to the generic
+// "failed after N retries" message.
+func TestRunTaskWithRetry_DeadlockRetriesExhausted(t *testing.T) {
+	retryConfig := fastRetryConfig()
+	r, task := newTestRunnerAndTask(retryConfig)
+	calls := 0
+	r.runTask = func(task *Task, conn *pgxpool.Pool, workerID int) error {
+		calls++
+		return errors.New("ERROR: deadlock detected")
+	}
+
+	err := r.RunTaskWithRetry(task, nil, r.config, 1)
+	if err == nil {
+		t.Fatal("expected an error after deadlock retries are exhausted, got nil")
+	}
+	if calls != retryConfig.DeadlockRetries+1 {
+		t.Errorf("expected %d calls (DeadlockRetries+1), got %d", retryConfig.DeadlockRetries+1, calls)
+	}
+	if got := err.Error(); !strings.Contains(got, "deadlock retries") {
+		t.Errorf("expected the deadlock-specific exhaustion message, got: %v", err)
+	}
+}
+
+// TestRunJob_WrapsTaskFailureError covers RunJob's error-wrap when a task
+// exhausts its retries: the returned error must name the failing task and
+// wrap the underlying retry-exhaustion error.
+func TestRunJob_WrapsTaskFailureError(t *testing.T) {
+	r, _ := newTestRunnerAndTask(fastRetryConfig())
+	r.runTask = func(task *Task, conn *pgxpool.Pool, workerID int) error {
+		return errors.New("boom")
+	}
+
+	job := NewJob([]int64{1}, []*Task{
+		NewTask("TEST: failing-task", Params{}, "irrelevant.sql", 1, -1),
+	})
+
+	err := r.RunJob(job, nil, 1)
+	if err == nil {
+		t.Fatal("expected RunJob to return an error when a task exhausts retries, got nil")
+	}
+	if !strings.Contains(err.Error(), "job failed at task") {
+		t.Errorf("expected RunJob's error to name the failing task, got: %v", err)
+	}
+}
+
+// TestRunner_GetSQLScript_MissingFileReturnsError covers the os.ReadFile
+// error path - no DB or fixture needed, just a path that doesn't exist.
+func TestRunner_GetSQLScript_MissingFileReturnsError(t *testing.T) {
+	r := NewRunner(&config.Config{})
+
+	if _, err := r.getSQLScript("/nonexistent/path/xyz.sql"); err == nil {
+		t.Error("expected an error for a missing SQL file, got nil")
+	}
+}
+
+// TestRunSingleTask_MissingSQLFileIsWrapped covers runSingleTask's own wrap
+// around a getSQLScript failure (distinct from calling getSQLScript
+// directly, above) - the missing-file check happens before conn is ever
+// touched, so nil is safe here and no DB is needed.
+func TestRunSingleTask_MissingSQLFileIsWrapped(t *testing.T) {
+	r := NewRunner(&config.Config{RetryConfig: fastRetryConfig()})
+	task := NewTask("TEST: missing file", Params{}, "/nonexistent/path/xyz.sql", 1, -1)
+
+	err := r.runSingleTask(task, nil, 1)
+	if err == nil {
+		t.Fatal("expected an error for a missing SQL file, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to read SQL file") {
+		t.Errorf("expected runSingleTask's own wrap message, got: %v", err)
 	}
 }

--- a/internal/process/sql_test.go
+++ b/internal/process/sql_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/thd-spatial-ai/city2tabula/internal/config"
 )
 
+// TestExecuteSQLScript_NilConfigReturnsError covers the guard clause that
+// short-circuits before touching sqlScript, conn, or cfg.GetSQLParameters —
+// safe to call with a nil conn too, since the nil-cfg check returns first.
+func TestExecuteSQLScript_NilConfigReturnsError(t *testing.T) {
+	err := executeSQLScript("SELECT 1;", nil, nil, 2, nil)
+	if err == nil {
+		t.Fatal("expected an error when cfg is nil, got nil")
+	}
+}
+
 // TestGetSQLParameterMap verifies that getSQLParameterMap correctly converts struct into a map containing key value pair. The key and corresponding value should match the source data.
 //
 // Use case: replaceParameter get the map of SQL parameter registered in config package, allowing it to find the parameter by key and replace it with the corresponding 'param' value.

--- a/internal/process/worker_test.go
+++ b/internal/process/worker_test.go
@@ -1,0 +1,14 @@
+package process
+
+import "testing"
+
+// TestRunJobQueue_EmptyQueueReturnsImmediately covers the early return before
+// any worker goroutine is spawned - safe to call with a nil conn/cfg since
+// IsEmpty() is checked before either is ever touched.
+func TestRunJobQueue_EmptyQueueReturnsImmediately(t *testing.T) {
+	queue := NewJobQueue()
+
+	if err := RunJobQueue(queue, nil, nil); err != nil {
+		t.Errorf("expected nil error for an empty queue, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Targets the 6 files Codecov flagged: \`orchestrator.go\` (67.61%), \`feature_extraction.go\` (77.48%), \`query.go\` (75%), \`worker.go\` (73.68%), \`runner.go\` (80.33%), \`sql.go\` (89.19%). \`internal/process\`: 83.3% -> 94.3%.

**Where a real unit test wasn't possible, an injectable seam stands in for a mock** (per your ask): \`RunTaskWithRetry\`'s deadlock/generic retry state machine was 63.6% covered — its branching can't be reliably driven by a real Postgres deadlock or real retry delays. \`Runner\` now has an injectable \`runTask\` func field (defaults to the real \`runSingleTask\`), so tests inject canned errors and assert exact retry counts / backoff branching in milliseconds using a 1ms-delay \`RetryConfig\`. `RunTaskWithRetry` and `runner.go` overall are now fully covered.

**Everywhere else, real tools over mocks:**
- \`createJob\` (orchestrator.go) is pure and dependency-free — every \`JobType\` branch, including \`MainTable\`/\`PyLovoLink\` (which no production caller currently passes), is directly unit-tested with no DB.
- The five queue-builder functions' \`LoadSQLScripts\`-failure wraps are covered by chdir-ing to an empty temp dir — no DB, since \`LoadSQLScripts\` only touches the filesystem. \`SupplementaryJobQueue\`'s success path had never been called by any test at all (0%).
- \`query.go\`'s three query functions, \`executeSQLScript\`'s \`conn.Exec\` failure, and \`Worker.Start\`'s error-continue branch are all driven against a real testcontainers Postgres:
  - A nonexistent schema name produces Postgres's own "relation does not exist" error.
  - A \`NUMERIC\` column holding a fractional value (950.5) makes the SQL query itself succeed while pgx's scan into a plain \`int\`/\`int64\` genuinely fails — not a simulated scan error.
  - \`Worker.Start\` gets one job with invalid SQL and one with valid SQL that leaves a detectable side effect (a marker table), proving the error-continue branch actually drains the rest of the channel instead of exiting early.

**Deliberately left uncovered** (all explained in commit messages): \`RunFeatureExtraction\`'s LOD3 success path (needs real LOD3 CityDB fixture data this repo doesn't have — only LOD2 fixtures exist); \`getBuildingIDsFromCityDB\`'s second-query error branch (can't isolate from its first query without contriving a mid-request schema drop); one statically-unreachable type-assertion branch in \`executeSQLScript\` (\`building_ids\` is always \`[]int64\` by the \`SQLParameters\` struct's own field type, so the type-assertion \`else\` can never actually fire).

## Test plan
- [x] \`go test -tags integration -timeout 15m ./internal/process/...\` — all pass, 94.3% coverage
- [x] \`go test -tags integration -timeout 15m ./internal/db/... ./internal/importer/...\` — no regressions
- [x] \`go build\`/\`go vet\` (with and without \`-tags integration\`)