### PR TITLE
test: cover internal/config (30.4% -> 100%)

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,68 @@
+package config
+
+import "testing"
+
+func TestGetCountry(t *testing.T) {
+	t.Setenv("COUNTRY", "  Germany  ")
+	if got := getCountry(); got != "germany" {
+		t.Errorf("getCountry() = %q, want %q", got, "germany")
+	}
+}
+
+// TestLoadConfig exercises the whole assembly path, including the derived
+// CountryCode lookup and every sub-loader it wires together.
+func TestLoadConfig(t *testing.T) {
+	t.Setenv("COUNTRY", "germany")
+	t.Setenv("DB_HOST", "dbhost")
+	t.Setenv("DB_PORT", "5433")
+	t.Setenv("DB_NAME", "testdb")
+	t.Setenv("DB_USER", "testuser")
+	t.Setenv("DB_PASSWORD", "testpass")
+	t.Setenv("CITYDB_TOOL_PATH", "/tools")
+	t.Setenv("CITYDB_SRID", "25832")
+	t.Setenv("CITYDB_SRS_NAME", "urn:ogc:def:crs:EPSG::25832")
+
+	cfg := LoadConfig()
+
+	if cfg.Country != "germany" {
+		t.Errorf("Country = %q, want %q", cfg.Country, "germany")
+	}
+	if cfg.CountryCode != "DE" {
+		t.Errorf("CountryCode = %q, want %q", cfg.CountryCode, "DE")
+	}
+	if cfg.DB == nil || cfg.DB.Host != "dbhost" {
+		t.Errorf("DB = %+v, want Host=dbhost", cfg.DB)
+	}
+	if cfg.Data == nil || cfg.Data.Lod2 != Lod2DataDir+"germany" {
+		t.Errorf("Data = %+v, want Lod2=%s", cfg.Data, Lod2DataDir+"germany")
+	}
+	if cfg.CityDB == nil || cfg.CityDB.ToolPath != "/tools" {
+		t.Errorf("CityDB = %+v, want ToolPath=/tools", cfg.CityDB)
+	}
+	if cfg.City2Tabula == nil {
+		t.Error("City2Tabula is nil")
+	}
+	if cfg.Batch == nil {
+		t.Error("Batch is nil")
+	}
+	if cfg.RetryConfig == nil {
+		t.Error("RetryConfig is nil")
+	}
+}
+
+// TestLoadConfig_UnsupportedCountry covers LoadConfig's own handling of
+// CountryCode's error return - it must still assemble a Config (with an
+// empty CountryCode), leaving Validate() to catch it later rather than
+// failing here.
+func TestLoadConfig_UnsupportedCountry(t *testing.T) {
+	t.Setenv("COUNTRY", "atlantis")
+
+	cfg := LoadConfig()
+
+	if cfg.Country != "atlantis" {
+		t.Errorf("Country = %q, want %q", cfg.Country, "atlantis")
+	}
+	if cfg.CountryCode != "" {
+		t.Errorf("CountryCode = %q, want empty for an unsupported country", cfg.CountryCode)
+	}
+}

--- a/internal/config/data_test.go
+++ b/internal/config/data_test.go
@@ -1,0 +1,35 @@
+package config
+
+import "testing"
+
+func TestLoadDataPaths(t *testing.T) {
+	t.Setenv("COUNTRY", "Germany")
+
+	dp := loadDataPaths()
+
+	if dp.Base != DataDir {
+		t.Errorf("Base = %q, want %q", dp.Base, DataDir)
+	}
+	if want := Lod2DataDir + "germany"; dp.Lod2 != want {
+		t.Errorf("Lod2 = %q, want %q", dp.Lod2, want)
+	}
+	if want := Lod3DataDir + "germany"; dp.Lod3 != want {
+		t.Errorf("Lod3 = %q, want %q", dp.Lod3, want)
+	}
+	if dp.Tabula != TabulaDataDir {
+		t.Errorf("Tabula = %q, want %q", dp.Tabula, TabulaDataDir)
+	}
+}
+
+func TestLoadDataPaths_UnsetCountry(t *testing.T) {
+	t.Setenv("COUNTRY", "")
+
+	dp := loadDataPaths()
+
+	if dp.Lod2 != Lod2DataDir {
+		t.Errorf("Lod2 = %q, want %q (no country suffix)", dp.Lod2, Lod2DataDir)
+	}
+	if dp.Lod3 != Lod3DataDir {
+		t.Errorf("Lod3 = %q, want %q (no country suffix)", dp.Lod3, Lod3DataDir)
+	}
+}

--- a/internal/config/database_test.go
+++ b/internal/config/database_test.go
@@ -1,0 +1,122 @@
+package config
+
+import "testing"
+
+func TestLoadDBConfig(t *testing.T) {
+	t.Setenv("DB_HOST", "myhost")
+	t.Setenv("DB_PORT", "1234")
+	t.Setenv("DB_NAME", "mydb")
+	t.Setenv("DB_USER", "myuser")
+	t.Setenv("DB_PASSWORD", "mypass")
+	t.Setenv("DB_SSL_MODE", "require")
+
+	db := loadDBConfig()
+
+	if db.Host != "myhost" {
+		t.Errorf("Host = %q, want %q", db.Host, "myhost")
+	}
+	if db.Port != "1234" {
+		t.Errorf("Port = %q, want %q", db.Port, "1234")
+	}
+	if db.Name != "mydb" {
+		t.Errorf("Name = %q, want %q", db.Name, "mydb")
+	}
+	if db.User != "myuser" {
+		t.Errorf("User = %q, want %q", db.User, "myuser")
+	}
+	if db.Password != "mypass" {
+		t.Errorf("Password = %q, want %q", db.Password, "mypass")
+	}
+	if db.SSLMode != "require" {
+		t.Errorf("SSLMode = %q, want %q", db.SSLMode, "require")
+	}
+	if db.Tables == nil {
+		t.Error("Tables is nil")
+	}
+	if db.Schemas == nil {
+		t.Error("Schemas is nil")
+	}
+	if db.SQL != nil {
+		t.Error("SQL should be nil until LoadSQLScripts populates it")
+	}
+}
+
+func TestLoadDBConfig_Defaults(t *testing.T) {
+	for _, key := range []string{"DB_HOST", "DB_PORT", "DB_NAME", "DB_USER", "DB_PASSWORD", "DB_SSL_MODE"} {
+		t.Setenv(key, "")
+	}
+
+	db := loadDBConfig()
+
+	if db.Host != "localhost" {
+		t.Errorf("Host = %q, want default %q", db.Host, "localhost")
+	}
+	if db.Port != "5432" {
+		t.Errorf("Port = %q, want default %q", db.Port, "5432")
+	}
+	if db.User != "postgres" {
+		t.Errorf("User = %q, want default %q", db.User, "postgres")
+	}
+	if db.Name != "" {
+		t.Errorf("Name = %q, want default empty", db.Name)
+	}
+}
+
+func TestLoadSchemas(t *testing.T) {
+	t.Setenv("PYLOVO_SCHEMA", "custom_pylovo")
+
+	s := loadSchemas()
+
+	cases := map[string]struct{ got, want string }{
+		"Public":      {s.Public, PublicSchema},
+		"CityDB":      {s.CityDB, CityDBSchema},
+		"CityDBPkg":   {s.CityDBPkg, CityDBPkgSchema},
+		"Lod2":        {s.Lod2, Lod2Schema},
+		"Lod3":        {s.Lod3, Lod3Schema},
+		"Tabula":      {s.Tabula, TabulaSchema},
+		"City2Tabula": {s.City2Tabula, City2TabulaSchema},
+		"Pylvo":       {s.Pylvo, "custom_pylovo"},
+	}
+	for field, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", field, c.got, c.want)
+		}
+	}
+}
+
+func TestLoadSchemas_PylvoDefault(t *testing.T) {
+	t.Setenv("PYLOVO_SCHEMA", "")
+
+	s := loadSchemas()
+
+	if s.Pylvo != PylvoSchemaName {
+		t.Errorf("Pylvo = %q, want default %q", s.Pylvo, PylvoSchemaName)
+	}
+}
+
+func TestSchemas_All(t *testing.T) {
+	s := loadSchemas()
+
+	got := s.All()
+	want := []string{s.Public, s.CityDB, s.CityDBPkg, s.Lod2, s.Lod3, s.Tabula, s.City2Tabula}
+
+	if len(got) != len(want) {
+		t.Fatalf("All() returned %d entries, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("All()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestLoadTables(t *testing.T) {
+	tb := loadTables()
+
+	if tb.Tabula != Tabula {
+		t.Errorf("Tabula = %q, want %q", tb.Tabula, Tabula)
+	}
+	if tb.TabulaVariant != TabulaVariant {
+		t.Errorf("TabulaVariant = %q, want %q", tb.TabulaVariant, TabulaVariant)
+	}
+}

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1,0 +1,145 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetEnv(t *testing.T) {
+	t.Run("returns env value when set", func(t *testing.T) {
+		t.Setenv("CITY2TABULA_TEST_GETENV_SET", "value")
+		if got := GetEnv("CITY2TABULA_TEST_GETENV_SET", "fallback"); got != "value" {
+			t.Errorf("GetEnv() = %q, want %q", got, "value")
+		}
+	})
+
+	t.Run("returns fallback when unset", func(t *testing.T) {
+		if got := GetEnv("CITY2TABULA_TEST_GETENV_UNSET", "fallback"); got != "fallback" {
+			t.Errorf("GetEnv() = %q, want %q", got, "fallback")
+		}
+	})
+
+	t.Run("returns fallback when set to empty string", func(t *testing.T) {
+		t.Setenv("CITY2TABULA_TEST_GETENV_EMPTY", "")
+		if got := GetEnv("CITY2TABULA_TEST_GETENV_EMPTY", "fallback"); got != "fallback" {
+			t.Errorf("GetEnv() = %q, want %q", got, "fallback")
+		}
+	})
+}
+
+func TestGetEnvAsInt(t *testing.T) {
+	t.Run("returns parsed int when valid", func(t *testing.T) {
+		t.Setenv("CITY2TABULA_TEST_GETENVASINT_VALID", "42")
+		if got := GetEnvAsInt("CITY2TABULA_TEST_GETENVASINT_VALID", 0); got != 42 {
+			t.Errorf("GetEnvAsInt() = %d, want %d", got, 42)
+		}
+	})
+
+	t.Run("returns fallback when unset", func(t *testing.T) {
+		if got := GetEnvAsInt("CITY2TABULA_TEST_GETENVASINT_UNSET", 7); got != 7 {
+			t.Errorf("GetEnvAsInt() = %d, want %d", got, 7)
+		}
+	})
+
+	t.Run("returns fallback when not a valid int", func(t *testing.T) {
+		t.Setenv("CITY2TABULA_TEST_GETENVASINT_INVALID", "not-a-number")
+		if got := GetEnvAsInt("CITY2TABULA_TEST_GETENVASINT_INVALID", 7); got != 7 {
+			t.Errorf("GetEnvAsInt() = %d, want %d", got, 7)
+		}
+	})
+}
+
+func TestNormalizeCountryName(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"already normalized", "germany", "germany"},
+		{"mixed case", "Germany", "germany"},
+		{"leading/trailing whitespace", "  germany  ", "germany"},
+		{"internal spaces become underscores", "United Kingdom", "united_kingdom"},
+		{"hyphens become underscores", "Czech-Republic", "czech_republic"},
+		{"empty stays empty", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeCountryName(tc.in); got != tc.want {
+				t.Errorf("normalizeCountryName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoadEnv only confirms LoadEnv doesn't error out or panic when no .env
+// file is present at the test's working directory (internal/config, not the
+// project root) - godotenv.Overload's error is deliberately swallowed, so
+// there is no observable branch to assert on beyond "it returns".
+func TestLoadEnv(t *testing.T) {
+	LoadEnv()
+}
+
+func validTestConfig() Config {
+	return Config{
+		Country:     "germany",
+		CountryCode: "DE",
+		DB: &DBConfig{
+			Name:     "testdb",
+			Host:     "localhost",
+			Port:     "5432",
+			User:     "postgres",
+			Password: "secret",
+		},
+		CityDB: &CityDB{
+			ToolPath: "/opt/citydb-tool",
+			SRID:     "25832",
+			SRSName:  "urn:ogc:def:crs:EPSG::25832",
+		},
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	t.Run("valid config returns nil", func(t *testing.T) {
+		if err := validTestConfig().Validate(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("reports every missing field", func(t *testing.T) {
+		cfg := validTestConfig()
+		cfg.DB.Name = ""
+		cfg.DB.Host = "  " // whitespace-only counts as missing
+		cfg.DB.Port = ""
+		cfg.DB.User = ""
+		cfg.DB.Password = ""
+		cfg.CityDB.ToolPath = ""
+		cfg.CityDB.SRID = ""
+		cfg.CityDB.SRSName = ""
+		cfg.Country = ""
+
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		for _, want := range []string{
+			"DB_NAME", "DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD",
+			"CITYDB_TOOL_PATH", "CITYDB_SRID", "CITYDB_SRS_NAME", "COUNTRY",
+		} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("expected error to mention %q, got: %v", want, err)
+			}
+		}
+	})
+
+	t.Run("unsupported country reports separately from missing fields", func(t *testing.T) {
+		cfg := validTestConfig()
+		cfg.CountryCode = ""
+
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "unsupported country") {
+			t.Errorf("expected an unsupported-country error, got: %v", err)
+		}
+	})
+}

--- a/internal/config/sql_test.go
+++ b/internal/config/sql_test.go
@@ -1,0 +1,237 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func projectRoot() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(file), "..", "..")
+}
+
+func TestGetSQLParameters(t *testing.T) {
+	cfg := &Config{
+		Country:     "germany",
+		CountryCode: "DE",
+		DB: &DBConfig{
+			Schemas: &Schemas{
+				Lod2: "lod2", Lod3: "lod3", City2Tabula: "c2t", Tabula: "tab",
+				Public: "public", CityDB: "citydb", CityDBPkg: "citydb_pkg", Pylvo: "pylovo",
+			},
+			Tables: &Tables{Tabula: "tab_table", TabulaVariant: "tab_variant_table"},
+		},
+		CityDB:      &CityDB{SRID: "25832"},
+		City2Tabula: &City2TabulaConfig{RoomHeight: "2.5"},
+	}
+
+	cases := []struct {
+		lod           int
+		wantLodSchema string
+	}{
+		{2, "lod2"},
+		{3, "lod3"},
+		{0, ""}, // neither 2 nor 3 -> empty
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("lod=%d", tc.lod), func(t *testing.T) {
+			params := cfg.GetSQLParameters(tc.lod, []int64{1, 2, 3})
+
+			if params.LodSchema != tc.wantLodSchema {
+				t.Errorf("LodSchema = %q, want %q", params.LodSchema, tc.wantLodSchema)
+			}
+			if params.LodLevel != tc.lod {
+				t.Errorf("LodLevel = %d, want %d", params.LodLevel, tc.lod)
+			}
+			if len(params.BuildingIDs) != 3 {
+				t.Errorf("BuildingIDs = %v, want 3 entries", params.BuildingIDs)
+			}
+			if params.SRID != "25832" {
+				t.Errorf("SRID = %q, want %q", params.SRID, "25832")
+			}
+			if params.City2TabulaSchema != "c2t" {
+				t.Errorf("City2TabulaSchema = %q, want %q", params.City2TabulaSchema, "c2t")
+			}
+			if params.TabulaSchema != "tab" {
+				t.Errorf("TabulaSchema = %q, want %q", params.TabulaSchema, "tab")
+			}
+			if params.PublicSchema != "public" {
+				t.Errorf("PublicSchema = %q, want %q", params.PublicSchema, "public")
+			}
+			if params.CityDBSchema != "citydb" {
+				t.Errorf("CityDBSchema = %q, want %q", params.CityDBSchema, "citydb")
+			}
+			if params.CityDBPkgSchema != "citydb_pkg" {
+				t.Errorf("CityDBPkgSchema = %q, want %q", params.CityDBPkgSchema, "citydb_pkg")
+			}
+			if params.Country != "germany" {
+				t.Errorf("Country = %q, want %q", params.Country, "germany")
+			}
+			if params.CountryCode != "DE" {
+				t.Errorf("CountryCode = %q, want %q", params.CountryCode, "DE")
+			}
+			if params.TabulaTable != "tab_table" {
+				t.Errorf("TabulaTable = %q, want %q", params.TabulaTable, "tab_table")
+			}
+			if params.TabulaVariantTable != "tab_variant_table" {
+				t.Errorf("TabulaVariantTable = %q, want %q", params.TabulaVariantTable, "tab_variant_table")
+			}
+			if params.RoomHeight != "2.5" {
+				t.Errorf("RoomHeight = %q, want %q", params.RoomHeight, "2.5")
+			}
+			if params.PylvoSchema != "pylovo" {
+				t.Errorf("PylvoSchema = %q, want %q", params.PylvoSchema, "pylovo")
+			}
+		})
+	}
+}
+
+func TestLoadSQLFilesFromDir(t *testing.T) {
+	t.Run("sorts files and ignores non-.sql files", func(t *testing.T) {
+		dir := t.TempDir()
+		for _, name := range []string{"02_second.sql", "01_first.sql", "10_tenth.sql", "readme.txt"} {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("SELECT 1;"), 0644); err != nil {
+				t.Fatalf("failed to write fixture %s: %v", name, err)
+			}
+		}
+
+		got, err := loadSQLFilesFromDir(dir)
+		if err != nil {
+			t.Fatalf("loadSQLFilesFromDir: %v", err)
+		}
+
+		want := []string{
+			filepath.Join(dir, "01_first.sql"),
+			filepath.Join(dir, "02_second.sql"),
+			filepath.Join(dir, "10_tenth.sql"),
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("empty directory returns an error", func(t *testing.T) {
+		_, err := loadSQLFilesFromDir(t.TempDir())
+		if err == nil {
+			t.Fatal("expected an error for a directory with no .sql files")
+		}
+		if !strings.Contains(err.Error(), "no SQL files found") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nonexistent directory returns an error", func(t *testing.T) {
+		// filepath.Glob doesn't error on a missing directory, it just finds
+		// no matches - so this hits the same "no SQL files found" branch.
+		_, err := loadSQLFilesFromDir(filepath.Join(t.TempDir(), "does", "not", "exist"))
+		if err == nil {
+			t.Fatal("expected an error for a nonexistent directory")
+		}
+		if !strings.Contains(err.Error(), "no SQL files found") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("malformed glob pattern returns a glob error", func(t *testing.T) {
+		// An unmatched "[" in the directory name makes filepath.Glob itself
+		// fail (ErrBadPattern) rather than simply finding no matches.
+		_, err := loadSQLFilesFromDir(filepath.Join(t.TempDir(), "bad[pattern"))
+		if err == nil {
+			t.Fatal("expected a glob syntax error")
+		}
+		if strings.Contains(err.Error(), "no SQL files found") {
+			t.Errorf("expected a glob syntax error, not the empty-dir error: %v", err)
+		}
+	})
+}
+
+// chdirWithSQLTree creates a fresh temp dir, chdirs the test into it, and
+// creates only the given relative directories (each with one stub .sql
+// file) - letting a test control exactly which of LoadSQLScripts' six
+// sequential loads succeeds and which one is first to fail.
+func chdirWithSQLTree(t *testing.T, dirs []string) {
+	t.Helper()
+	root := t.TempDir()
+	t.Chdir(root)
+
+	for _, d := range dirs {
+		full := filepath.Join(root, d)
+		if err := os.MkdirAll(full, 0755); err != nil {
+			t.Fatalf("failed to create %s: %v", d, err)
+		}
+		if err := os.WriteFile(filepath.Join(full, "01_stub.sql"), []byte("SELECT 1;"), 0644); err != nil {
+			t.Fatalf("failed to write stub SQL into %s: %v", d, err)
+		}
+	}
+}
+
+func TestConfig_LoadSQLScripts_Failures(t *testing.T) {
+	// In LoadSQLScripts' call order - each case creates every directory up
+	// to (but not including) the one that should be missing, isolating that
+	// specific early-return branch.
+	allDirs := []string{
+		strings.TrimSuffix(SQLMainScriptDir, string(os.PathSeparator)),
+		strings.TrimSuffix(SQLSupplementaryScriptDir, string(os.PathSeparator)),
+		strings.TrimSuffix(SQLPylvoLinkScriptDir, string(os.PathSeparator)),
+		strings.TrimSuffix(SQLMainSchemaPath, string(os.PathSeparator)),
+		strings.TrimSuffix(SQLSupplementarySchemaPath, string(os.PathSeparator)),
+		strings.TrimSuffix(SQLTrainingFunctionsPath, string(os.PathSeparator)),
+	}
+
+	cases := []struct {
+		name       string
+		createUpTo int
+	}{
+		{"main scripts missing", 0},
+		{"supplementary scripts missing", 1},
+		{"pylovo link scripts missing", 2},
+		{"main schema missing", 3},
+		{"supplementary schema missing", 4},
+		{"function scripts missing", 5},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			chdirWithSQLTree(t, allDirs[:tc.createUpTo])
+
+			cfg := &Config{}
+			_, err := cfg.LoadSQLScripts()
+			if err == nil {
+				t.Fatalf("expected an error when %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestConfig_LoadSQLScripts_Success(t *testing.T) {
+	t.Chdir(projectRoot())
+
+	cfg := &Config{}
+	scripts, err := cfg.LoadSQLScripts()
+	if err != nil {
+		t.Fatalf("LoadSQLScripts: %v", err)
+	}
+
+	for name, got := range map[string][]string{
+		"MainScripts":               scripts.MainScripts,
+		"SupplementaryScripts":      scripts.SupplementaryScripts,
+		"PyLovoLinkScripts":         scripts.PyLovoLinkScripts,
+		"MainTableScripts":          scripts.MainTableScripts,
+		"SupplementaryTableScripts": scripts.SupplementaryTableScripts,
+		"FunctionScripts":           scripts.FunctionScripts,
+	} {
+		if len(got) == 0 {
+			t.Errorf("%s: expected at least one script, got none", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds direct unit tests for `internal/config`'s five previously-untested files (`config.go`, `data.go`, `database.go`, `env.go`, `sql.go`), which sat at 0% each apart from incidental coverage picked up through other packages' tests.
- Coverage: `internal/config` 30.4% -> 100%.

## What's covered
- `env.go`: `GetEnv`/`GetEnvAsInt` fallback behaviour, `normalizeCountryName`, and every branch of `Config.Validate` (each missing-field append, the unsupported-country check).
- `config.go`: `LoadConfig`'s full assembly (including the unsupported-country path, which still assembles a `Config` with an empty `CountryCode` for `Validate` to catch later).
- `data.go` / `database.go`: `loadDataPaths`, `loadDBConfig` (set + default), `loadSchemas` (incl. `PYLOVO_SCHEMA` override/default), `Schemas.All`, `loadTables`.
- `sql.go`: `GetSQLParameters` across LOD 2/3/other, `loadSQLFilesFromDir`'s sort/filter/empty-dir/nonexistent-dir/malformed-glob-pattern branches, and `Config.LoadSQLScripts`'s six sequential directory loads — each of the six early-return branches isolated by fabricating a partial `sql/` tree under a temp-dir `t.Chdir`, plus a real success run against the project's actual `sql/` directory.

`batch.go`, `city2tabula.go`, `citydb.go`, and `country.go` already had dedicated test files from earlier coverage passes and needed no changes.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` (with and without `-tags integration`)
- [x] `go test ./...`
- [x] `go tool cover -func` confirms `internal/config` at 100.0% of statements