### PR TITLE
test: cover internal/db's remaining gaps (84.1% -> 87.3%)

### DIFF
--- a/internal/db/composite_success_test.go
+++ b/internal/db/composite_success_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thd-spatial-ai/city2tabula/internal/config"
+	"github.com/thd-spatial-ai/city2tabula/internal/db"
+)
+
+// setupMinimalTabulaTable pre-creates a minimal stand-in tabula.tabula table
+// - just the 17 columns sql/scripts/supplementary/01_extract_tabula_attributes.sql
+// actually SELECTs, not the real 216-column TABULA project format this repo
+// doesn't ship. Only safe for callers that DON'T go on to run
+// sql/schema/supplementary/01_create_tabula_tables.sql afterwards: that
+// script unconditionally DROP TABLEs tabula.tabula before its own CREATE
+// TABLE IF NOT EXISTS, wiping this fixture out and replacing it with the
+// real 216-column shape (RunCity2TabulaDBSetup runs that script, so anything
+// that calls it - CreateCompleteDatabase, ResetCompleteDatabase,
+// ResetCity2TabulaSchemas - can't use this trick for a full success test;
+// see internal/importer's supplementary_integration_test.go, which sidesteps
+// this by running RunCity2TabulaDBSetup itself first and only overriding the
+// table afterwards). ImportAllData never touches this DDL at all, so it's
+// the one composite entry point this fixture works for directly.
+//
+// The schema must be the literal "tabula", not cfg.DB.Schemas.Tabula:
+// importer.ImportCsvWithPsql hardcodes "\copy tabula.tabula FROM ..." rather
+// than substituting the configured schema/table name (unlike the extraction
+// SQL, which is correctly parameterized) - a real inconsistency, flagged
+// separately, not something to route around silently here.
+func setupMinimalTabulaTable(t *testing.T, ctx context.Context) {
+	t.Helper()
+	t.Cleanup(func() { testPool.Exec(ctx, `DROP SCHEMA IF EXISTS tabula CASCADE`) })
+	if _, err := testPool.Exec(ctx, `DROP SCHEMA IF EXISTS tabula CASCADE`); err != nil {
+		t.Fatalf("failed to reset tabula schema: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `CREATE SCHEMA tabula`); err != nil {
+		t.Fatalf("failed to create tabula schema: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		CREATE TABLE tabula.tabula (
+			id INTEGER,
+			"Code_BuildingVariant" TEXT,
+			"Number_BuildingVariant" INTEGER,
+			"Year1_Building" INTEGER,
+			"Year2_Building" INTEGER,
+			"V_C" DOUBLE PRECISION,
+			"A_C_National" DOUBLE PRECISION,
+			"n_Storey" INTEGER,
+			"Code_ComplexFootprint" TEXT,
+			"Code_AttachedNeighbours" TEXT,
+			"Code_ComplexRoof" TEXT,
+			"A_Roof_1" DOUBLE PRECISION,
+			"A_Roof_2" DOUBLE PRECISION,
+			"A_Wall_1" DOUBLE PRECISION,
+			"A_Wall_2" DOUBLE PRECISION,
+			"A_Wall_3" DOUBLE PRECISION,
+			"A_C_ExtDim" DOUBLE PRECISION,
+			"Code_BuildingSizeClass" TEXT
+		);`,
+	); err != nil {
+		t.Fatalf("failed to create minimal tabula.tabula fixture: %v", err)
+	}
+}
+
+// writeMinimalTabulaCSV writes one data row matching setupMinimalTabulaTable's
+// column order exactly - empty fields become NULL under COPY ... CSV, which
+// COALESCE(..., 0) in 01_extract_tabula_attributes.sql then zeroes out.
+func writeMinimalTabulaCSV(t *testing.T, dir, country string) {
+	t.Helper()
+	header := `id,Code_BuildingVariant,Number_BuildingVariant,Year1_Building,Year2_Building,V_C,A_C_National,n_Storey,Code_ComplexFootprint,Code_AttachedNeighbours,Code_ComplexRoof,A_Roof_1,A_Roof_2,A_Wall_1,A_Wall_2,A_Wall_3,A_C_ExtDim,Code_BuildingSizeClass`
+	row := `1,TEST.VARIANT.001,1,1990,2000,500.0,150.0,3,Regular,B_Alone,Simple,60.0,,40.0,40.0,,145.0,SFH`
+	csv := header + "\n" + row + "\n"
+	path := filepath.Join(dir, country+".csv")
+	if err := os.WriteFile(path, []byte(csv), 0644); err != nil {
+		t.Fatalf("failed to write CSV fixture: %v", err)
+	}
+}
+
+// TestImportAllData_Success drives ImportAllData's own success return
+// directly: the minimal tabula.tabula fixture above satisfies
+// ImportSupplementaryData for real, and ImportCityDBData's LOD2/LOD3 import
+// is skipped (warn, not fail) by pointing Data.Lod2/Lod3 at nonexistent
+// directories - so every step runs for real against Postgres and returns
+// nil.
+func TestImportAllData_Success(t *testing.T) {
+	ctx := context.Background()
+	t.Chdir(projectRoot()) // ImportSupplementaryData loads sql/scripts/supplementary/ relative to cwd
+	cfg := fullCfg("citytabula_dbtest")
+	cfg.DB.Schemas.Tabula = "tabula" // must match ImportCsvWithPsql's hardcoded "tabula.tabula" target
+	cfg.DB.Schemas.City2Tabula = "iad_success_c2t"
+	dropSchemasOnCleanup(t, ctx, cfg.DB.Schemas.City2Tabula)
+	cfg.CityDB.ToolPath = writeFakeCityDBExecutable(t, 0)
+	cfg.Country = "germany"
+
+	dataDir := t.TempDir()
+	writeMinimalTabulaCSV(t, dataDir, cfg.Country)
+	cfg.Data = &config.DataPaths{
+		Tabula: dataDir + string(filepath.Separator),
+		Lod2:   "/nonexistent/lod2",
+		Lod3:   "/nonexistent/lod3",
+	}
+
+	if _, err := testPool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS `+cfg.DB.Schemas.City2Tabula); err != nil {
+		t.Fatalf("failed to seed city2tabula schema: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		CREATE TABLE `+cfg.DB.Schemas.City2Tabula+`.tabula_variant (
+			id SERIAL PRIMARY KEY,
+			tabula_variant_code_id INTEGER NOT NULL UNIQUE,
+			tabula_variant_code TEXT NOT NULL,
+			max_volume DOUBLE PRECISION,
+			total_area DOUBLE PRECISION,
+			construction_year_1 INTEGER,
+			construction_year_2 INTEGER,
+			footprint_area DOUBLE PRECISION,
+			number_of_storeys INTEGER,
+			footprint_complexity INTEGER CHECK (footprint_complexity IN (-1, 0, 1, 2)),
+			attached_neighbour_class INTEGER CHECK (attached_neighbour_class IN (-1, 0, 1, 2)),
+			roof_complexity INTEGER CHECK (roof_complexity IN (-1, 0, 1, 2)),
+			area_total_roof DOUBLE PRECISION,
+			area_total_wall DOUBLE PRECISION,
+			area_total_floor DOUBLE PRECISION,
+			building_size_class INTEGER CHECK (building_size_class IN (-1, 0, 1, 2, 3))
+		);`,
+	); err != nil {
+		t.Fatalf("failed to seed tabula_variant table: %v", err)
+	}
+	setupMinimalTabulaTable(t, ctx)
+
+	if err := db.ImportAllData(cfg, testPool); err != nil {
+		t.Fatalf("ImportAllData: %v", err)
+	}
+
+	// RunJobQueue never returns an error for a failed task (see the
+	// coverage-push PR description), so a nil error here doesn't by itself
+	// prove the extraction SQL ran - check the resulting row for real.
+	var code string
+	if err := testPool.QueryRow(ctx,
+		`SELECT tabula_variant_code FROM `+cfg.DB.Schemas.City2Tabula+`.tabula_variant WHERE tabula_variant_code_id = 1`,
+	).Scan(&code); err != nil {
+		t.Fatalf("failed to read the inserted tabula_variant row: %v", err)
+	}
+	if code != "TEST.VARIANT.001" {
+		t.Errorf("tabula_variant_code = %q, want %q", code, "TEST.VARIANT.001")
+	}
+}
+
+// TestImportAllData_ImportCityDBDataFailure covers ImportAllData's second
+// error wrap: ImportSupplementaryData succeeds for real (minimal fixture),
+// then ImportCityDBData fails because the fake citydb executable rejects
+// even -help.
+func TestImportAllData_ImportCityDBDataFailure(t *testing.T) {
+	ctx := context.Background()
+	t.Chdir(projectRoot())
+	cfg := fullCfg("citytabula_dbtest")
+	cfg.DB.Schemas.Tabula = "tabula" // must match ImportCsvWithPsql's hardcoded "tabula.tabula" target
+	cfg.DB.Schemas.City2Tabula = "iad_citydb_fail_c2t"
+	dropSchemasOnCleanup(t, ctx, cfg.DB.Schemas.City2Tabula)
+	cfg.CityDB.ToolPath = writeFakeCityDBExecutable(t, 1) // fails -help
+	cfg.Country = "germany"
+
+	dataDir := t.TempDir()
+	writeMinimalTabulaCSV(t, dataDir, cfg.Country)
+	cfg.Data = &config.DataPaths{Tabula: dataDir + string(filepath.Separator)}
+
+	if _, err := testPool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS `+cfg.DB.Schemas.City2Tabula); err != nil {
+		t.Fatalf("failed to seed city2tabula schema: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		CREATE TABLE `+cfg.DB.Schemas.City2Tabula+`.tabula_variant (
+			id SERIAL PRIMARY KEY,
+			tabula_variant_code_id INTEGER NOT NULL UNIQUE,
+			tabula_variant_code TEXT NOT NULL,
+			max_volume DOUBLE PRECISION,
+			total_area DOUBLE PRECISION,
+			construction_year_1 INTEGER,
+			construction_year_2 INTEGER,
+			footprint_area DOUBLE PRECISION,
+			number_of_storeys INTEGER,
+			footprint_complexity INTEGER CHECK (footprint_complexity IN (-1, 0, 1, 2)),
+			attached_neighbour_class INTEGER CHECK (attached_neighbour_class IN (-1, 0, 1, 2)),
+			roof_complexity INTEGER CHECK (roof_complexity IN (-1, 0, 1, 2)),
+			area_total_roof DOUBLE PRECISION,
+			area_total_wall DOUBLE PRECISION,
+			area_total_floor DOUBLE PRECISION,
+			building_size_class INTEGER CHECK (building_size_class IN (-1, 0, 1, 2, 3))
+		);`,
+	); err != nil {
+		t.Fatalf("failed to seed tabula_variant table: %v", err)
+	}
+	setupMinimalTabulaTable(t, ctx)
+
+	err := db.ImportAllData(cfg, testPool)
+	if err == nil {
+		t.Fatal("expected an error when ImportCityDBData fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to import CityDB data") {
+		t.Errorf("expected ImportAllData's own error wrap, got: %v", err)
+	}
+}

--- a/internal/db/connection_error_test.go
+++ b/internal/db/connection_error_test.go
@@ -3,6 +3,7 @@
 package db_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/thd-spatial-ai/city2tabula/internal/db"
@@ -43,6 +44,27 @@ func TestConnectPool_PropagatesEnsureDatabaseFailure(t *testing.T) {
 	pool, err := db.ConnectPool(cfg)
 	if err == nil {
 		t.Fatal("expected ConnectPool to fail when EnsureDatabase fails, got nil")
+	}
+	if pool != nil {
+		t.Error("expected a nil pool on failure")
+	}
+}
+
+// TestConnectPool_ParseConfigFailure covers ConnectPool's own "parse pool
+// config failed" wrap: EnsureDatabase succeeds against the real bootstrap
+// DB (real host/port), then a negative Batch.Threads makes the DSN's
+// pool_max_conns=%d segment parse as an invalid (too small) value, failing
+// pgxpool.ParseConfig itself - no unreachable target DB needed.
+func TestConnectPool_ParseConfigFailure(t *testing.T) {
+	cfg := testConfig("connect_pool_parseconfig_test")
+	cfg.Batch.Threads = -1
+
+	pool, err := db.ConnectPool(cfg)
+	if err == nil {
+		t.Fatal("expected a parse pool config error for a negative pool_max_conns, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse pool config failed") {
+		t.Errorf("expected ConnectPool's own error wrap, got: %v", err)
 	}
 	if pool != nil {
 		t.Error("expected a nil pool on failure")

--- a/internal/db/setup_test.go
+++ b/internal/db/setup_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/thd-spatial-ai/city2tabula/internal/config"
@@ -100,15 +101,38 @@ func TestRunCity2TabulaDBSetup_Success(t *testing.T) {
 	}
 }
 
-// TestSetupMainDB_LoadSQLScriptsFailurePropagates and its supplementary
-// counterpart drive the LoadSQLScripts error-wrap in each of RunCity2TabulaDBSetup's
-// two internal steps - filesystem-only, no DB touched (the failure happens
-// before any SQL runs).
+// TestRunCity2TabulaDBSetup_LoadSQLScriptsFailurePropagates drives setupMainDB's
+// own "failed to build main DB setup queue" wrap. City2Tabula/Tabula schema
+// names must be non-empty here: CreateSchemas quotes its identifier
+// (`CREATE SCHEMA IF NOT EXISTS ""`is valid SQL), so an empty schema name
+// would let CreateSchemas succeed and this test would - misleadingly - be
+// failing at a different, earlier step than the one it claims to cover.
 func TestRunCity2TabulaDBSetup_LoadSQLScriptsFailurePropagates(t *testing.T) {
-	t.Chdir(t.TempDir())
+	ctx := context.Background()
 	cfg := testConfig("citytabula_dbtest")
+	cfg.DB.Schemas.City2Tabula = "rc2t_loadsql_fail_c2t"
+	cfg.DB.Schemas.Tabula = "rc2t_loadsql_fail_tabula"
+	dropSchemasOnCleanup(t, ctx, cfg.DB.Schemas.City2Tabula, cfg.DB.Schemas.Tabula)
 
-	if err := db.RunCity2TabulaDBSetup(cfg, testPool); err == nil {
-		t.Error("expected RunCity2TabulaDBSetup to propagate a LoadSQLScripts failure, got nil")
+	t.Chdir(t.TempDir())
+
+	err := db.RunCity2TabulaDBSetup(cfg, testPool)
+	if err == nil {
+		t.Fatal("expected RunCity2TabulaDBSetup to propagate a LoadSQLScripts failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to build main DB setup queue") {
+		t.Errorf("expected setupMainDB's own error wrap, got: %v", err)
 	}
 }
+
+// NOTE: setupMainDB's and setupSupplementaryDB's "main/supplementary DB setup
+// failed" wraps (around process.RunJobQueue's error) are currently dead code:
+// RunJobQueue (internal/process/worker.go) always returns nil once its queue
+// is non-empty - Worker.Start logs a failed job via utils.Error.Printf and
+// just `continue`s, never surfacing the error past the WaitGroup. Confirmed
+// empirically: a schema name that breaks the DDL's raw SQL substitution logs
+// real ERROR/WARN lines for every failing task, yet RunCity2TabulaDBSetup
+// still returns nil. See the coverage-push memory/PR description for this
+// finding - it's a real bug affecting every RunJobQueue caller (DB setup,
+// feature extraction, PyLovo link build), not a test gap, and is out of
+// scope to fix as part of this coverage-only change.


### PR DESCRIPTION
## Summary
- `internal/db` coverage: 84.1% -> 87.3% (`ImportAllData` and `RunCity2TabulaDBSetup` now 100%).
- Fixed a mislabeled existing test (`TestRunCity2TabulaDBSetup_LoadSQLScriptsFailurePropagates`) that was actually failing at `CreateSchemas` due to empty schema names, not at the `setupMainDB` branch it claimed to cover.

## Two behavioral findings from this pass (not fixed here - flagging for a decision, not silently working around)

1. **`process.RunJobQueue` never returns a non-nil error once its queue is non-empty.** `Worker.Start` (`internal/process/worker.go`) catches `runner.RunJob`'s error, logs it, and just `continue`s - the error never reaches the `WaitGroup`, so `RunJobQueue` always returns `nil` regardless of how many jobs/tasks failed. This makes `setupMainDB`/`setupSupplementaryDB`'s own `"...DB setup failed"` wraps dead code (confirmed empirically: real SQL syntax errors log ERROR/WARN lines yet the caller still gets `nil`). It affects every `RunJobQueue` caller: DB setup, feature extraction (`internal/process/feature_extraction.go`), and PyLovo link build - a task failure anywhere in the pipeline is currently silent to the caller.
2. **`importer.ImportCsvWithPsql` hardcodes its `\copy` target as literal `tabula.tabula`** rather than substituting `config.DB.Schemas.Tabula`/`config.DB.Tables.Tabula` (`internal/importer/supplementary.go:80`), unlike the downstream extraction SQL, which correctly uses `{tabula_schema}.{tabula_table}` placeholders. Only bites if someone configures a non-default Tabula schema/table name, but it's a real inconsistency between the two steps of the same import pipeline.

Both are called out in code comments where they made a would-be test unreachable, and are cheap to hand off from here since I already have the repro path.

## What's covered
- `ImportAllData`: full success (real minimal `tabula.tabula` + `tabula_variant` fixtures, LOD2/LOD3 import skipped via nonexistent data dirs - genuinely verified against the resulting row, not just a `nil` return, given finding #1 above) and its second error wrap (`ImportCityDBData` failing after `ImportSupplementaryData` succeeds).
- `RunCity2TabulaDBSetup`: now 100%, including the corrected `LoadSQLScripts`-failure test.
- `ConnectPool`: added the `"parse pool config failed"` branch (negative `Batch.Threads` -> invalid `pool_max_conns` in the DSN) - reachable without decoupling a working bootstrap connection from a failing target one, since `EnsureDatabase` still succeeds for real first.

## Deliberately left uncovered
`CreateCompleteDatabase`/`ResetCompleteDatabase`/`ResetCity2TabulaSchemas`'s full success paths: `sql/schema/supplementary/01_create_tabula_tables.sql` unconditionally `DROP TABLE`s `tabula.tabula` before recreating it, wiping any pre-seeded minimal fixture before `ImportAllData` runs. Unlike `internal/importer`'s own tests (which run `RunCity2TabulaDBSetup` first and only override the table afterwards), these three call `RunCity2TabulaDBSetup` and `ImportAllData` back to back with no seam to intervene - needs the real 216-column TABULA project CSV this repo doesn't ship. Also several `if err != nil { Warn }` branches in `setup.go` (`DropAllSchemas`'s and `ResetCityDBOnly`'s checks on `DropCityDBSchemas`, and `ResetCompleteDatabase`'s check on `DropAllSchemas`) are statically unreachable given the current implementation - both `DropCityDBSchemas` and `DropAllSchemas` always return `nil` regardless of internal warnings.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` (with and without `-tags integration`)
- [x] `go test ./...`
- [x] `go test -tags integration -timeout 15m ./internal/db/... ./internal/importer/... ./internal/process/...`